### PR TITLE
Feature: integrate eth_call returns true on Flashbots RPC contract to allow dApps to check if their users are using Flashbots Protect RPC

### DIFF
--- a/server/request.go
+++ b/server/request.go
@@ -57,6 +57,15 @@ type RpcRequest struct {
 	txFrom   string
 }
 
+// map[data:0xb9dc7766 from:0x34ca25940dbb0ce7e95db1fed8f8acf2b0ee9b09 gas:0x2dc6c0 to:0xd30149eca3c00be8aa36799ccfe171d79b4155d9 value:0x0]
+type ethCallRequest struct {
+	data  string
+	from  string
+	gas   string
+	to    string
+	value string
+}
+
 func NewRpcRequest(respw *http.ResponseWriter, req *http.Request, proxyUrl string) *RpcRequest {
 	return &RpcRequest{
 		respw:           respw,
@@ -151,6 +160,15 @@ func (r *RpcRequest) process() {
 					return
 				}
 			}
+		}
+		if r.jsonReq.Method == "eth_call" && len(r.jsonReq.Params) > 0 {
+			ethCallReq := r.jsonReq.Params[0].(map[string]interface{})
+			addressTo := strings.ToLower(ethCallReq["to"].(string))
+
+			if addressTo == "0xd30149eca3c00be8aa36799ccfe171d79b4155d9" {
+				r.log("Address is to the Flashbots RPC Contract")
+			}
+
 		}
 
 		// Just proxy the request to a node

--- a/server/request.go
+++ b/server/request.go
@@ -165,8 +165,9 @@ func (r *RpcRequest) process() {
 			ethCallReq := r.jsonReq.Params[0].(map[string]interface{})
 			addressTo := strings.ToLower(ethCallReq["to"].(string))
 
-			if addressTo == "0xd30149eca3c00be8aa36799ccfe171d79b4155d9" {
-				r.log("Address is to the Flashbots RPC Contract")
+			if addressTo == "0xf1a54b0759b58661cea17cff19dd37940a9b5f1a" {
+				r.handle_eth_call_to_FlashRPC_Contract()
+				return
 			}
 
 		}
@@ -177,6 +178,23 @@ func (r *RpcRequest) process() {
 		} else {
 			r.log("Proxy to node failed: %s", r.jsonReq.Method)
 		}
+	}
+}
+
+func (r *RpcRequest) handle_eth_call_to_FlashRPC_Contract() {
+	resp := JsonRpcResponse{
+		Id:      r.jsonReq.Id,
+		Version: "2.0",
+		Result:  "0x0000000000000000000000000000000000000000000000000000000000000001",
+	}
+
+	if err := json.NewEncoder(*r.respw).Encode(resp); err != nil {
+		r.logError("Intercepting eth_call failed: %v", err)
+		(*r.respw).WriteHeader(http.StatusInternalServerError)
+		return
+	} else {
+		r.log("Intercepting eth_call successful")
+		return
 	}
 }
 

--- a/server/request.go
+++ b/server/request.go
@@ -57,7 +57,6 @@ type RpcRequest struct {
 	txFrom   string
 }
 
-// map[data:0xb9dc7766 from:0x34ca25940dbb0ce7e95db1fed8f8acf2b0ee9b09 gas:0x2dc6c0 to:0xd30149eca3c00be8aa36799ccfe171d79b4155d9 value:0x0]
 type ethCallRequest struct {
 	data  string
 	from  string
@@ -165,6 +164,9 @@ func (r *RpcRequest) process() {
 			ethCallReq := r.jsonReq.Params[0].(map[string]interface{})
 			addressTo := strings.ToLower(ethCallReq["to"].(string))
 
+			// Only handle calls to the Flashbots RPC check contract
+			// 0xf1a54b075 --> 0xflashbots
+			// https://etherscan.io/address/0xf1a54b0759b58661cea17cff19dd37940a9b5f1a#readContract
 			if addressTo == "0xf1a54b0759b58661cea17cff19dd37940a9b5f1a" {
 				r.handle_eth_call_to_FlashRPC_Contract()
 				return


### PR DESCRIPTION
As the title says this PR introduces an intercept on eth_call made to the Flashbots RPC check contract here:
https://etherscan.io/address/0xf1a54b0759b58661cea17cff19dd37940a9b5f1a#readContract

This contract will always return false if talking to a standard RPC endpoint, but will return true if using the Flashbots Protect RPC. If a dApp were to call `isFlashbotsRPC()` then they could use the result to tell whether users are using the Flashbots Protect RPC or not.

Of course, they would be able to prompt users to add the Flashbots Protect RPC if not :)