### PR TITLE
fix(utils): add origin for metamask firefox extension

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -22,8 +22,14 @@ func GetIP(r *http.Request) string {
 	return r.RemoteAddr
 }
 
+// CHROME_ID: nkbihfbeogaeaoehlefnkodbefgpgknn
 func IsMetamask(r *http.Request) bool {
 	return r.Header.Get("Origin") == "chrome-extension://nkbihfbeogaeaoehlefnkodbefgpgknn"
+}
+
+// FIREFOX_ID: webextension@metamask.io
+func IsMetamaskMoz(r *http.Request) bool {
+	return r.Header.Get("Origin") == "moz-extension://57f9aaf6-270a-154f-9a8a-632d0db4128c"
 }
 
 func ProxyRequest(proxyUrl string, body []byte) (*http.Response, error) {


### PR DESCRIPTION
unsure of preference on how to handle the different browser versions, so before any other changes would like clarification @bertmiller 

if you would like some of my notes on Metamask can oblige 