### PR TITLE
failed getTxReceipt after user received 4x wrong nonce

### DIFF
--- a/server/request.go
+++ b/server/request.go
@@ -156,9 +156,12 @@ func (r *RpcRequest) process() {
 		// Proxy the request to a node
 		readJsonRpcSuccess, proxyHttpStatus, jsonResp := r.proxyRequestRead(r.defaultProxyUrl)
 
-		// After proxy, perhaps check backend [MM fix #3 step 2]
 		if r.jsonReq.Method == "eth_getTransactionReceipt" {
-			r.check_post_getTransactionReceipt(jsonResp)
+			// Perhaps enable the nonce fix after proxying to the node
+			requestFinished := r.check_post_getTransactionReceipt(jsonResp)
+			if requestFinished {
+				return
+			}
 		}
 
 		// Write the response to user

--- a/server/util.go
+++ b/server/util.go
@@ -119,8 +119,15 @@ func SendRpcAndParseResponseTo(url string, req *JsonRpcRequest) (*JsonRpcRespons
 		return nil, errors.Wrap(err, "read")
 	}
 
-	// Unmarshall JSON-RPC response and check for error inside
 	jsonRpcResp := new(JsonRpcResponse)
+	errorResp := new(RelayErrorResponse)
+	if err := json.Unmarshal(respData, errorResp); err == nil && errorResp.Error != "" {
+		// relay returned an error. Convert to standard JSON-RPC error
+		jsonRpcResp.Error = &JsonRpcError{Message: errorResp.Error}
+		return jsonRpcResp, nil
+	}
+
+	// Unmarshall JSON-RPC response and check for error inside
 	if err := json.Unmarshal(respData, jsonRpcResp); err != nil {
 		return nil, errors.Wrap(err, "unmarshal")
 	}


### PR DESCRIPTION
This PR implements an error response on `getTransactionReceipt` after Metamask has received the wrong nonce 4x (at which point Metamask shows the tx as dropped).

An error response on `getTransactionReceipt` allows websites/dapps like matcha.xyz to show that the transaction has actually failed, instead of being stuck in pending, because a proxied getTransactionReceipt still returns null (the tx never made it to mempool).

As an alternative, we could return an error on `getTransactionReceipt` immediately once the transaction API returns failed state, but in this case Metamask would still show the tx as pending for a minute or two, until it has received the nonces 4x.

