### PR TITLE
skip serializing result if not set

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -28,7 +28,7 @@ func NewJsonRpcRequest1(id interface{}, method string, param interface{}) *JsonR
 
 type JsonRpcResponse struct {
 	Id      interface{}     `json:"id"`
-	Result  json.RawMessage `json:"result"`
+	Result  json.RawMessage `json:"result,omitempty"`
 	Error   *JsonRpcError   `json:"error,omitempty"`
 	Version string          `json:"jsonrpc"`
 }


### PR DESCRIPTION
Without `omitempty`, `result` field is serialized even when not populated, causing jsonrpc_core crate to fail deserializing failure response:

https://docs.rs/jsonrpc-core/latest/jsonrpc_core/types/response/struct.Failure.html
(it denies deserialization if unexpected fields like `result` exist)

This PR adds `omitempty` in order to align with the general expectations.