### PR TITLE
filter out duplicate bundle txs

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -103,3 +103,14 @@ func GetTxStatus(txHash string) (*types.PrivateTxApiResponse, error) {
 
 	return respObj, nil
 }
+
+func Contains(arr []string, element string) bool {
+	var result bool = false
+	for _, x := range arr {
+		if x == element {
+			result = true
+			break
+		}
+	}
+	return result
+}


### PR DESCRIPTION
MetaMask will repeatedly send the same transaction as time passes, so this is a measure to prevent a cached bundle from getting maxed out (16 txs) for no reason.

Not sure if the `Contains` function is the most optimal implementation -- Go isn't my top language. But it works :)