### PR TITLE
feat(server): redirect `GET /fast` to corresponding docs page

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3,13 +3,14 @@ package server
 import (
 	"crypto/ecdsa"
 	"encoding/json"
-	"github.com/flashbots/rpc-endpoint/database"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/flashbots/rpc-endpoint/database"
 
 	"github.com/ethereum/go-ethereum/log"
 
@@ -100,7 +101,11 @@ func (s *RpcEndPointServer) HandleHttpRequest(respw http.ResponseWriter, req *ht
 	setCorsHeaders(respw)
 
 	if req.Method == http.MethodGet {
-		http.Redirect(respw, req, "https://docs.flashbots.net/flashbots-protect/rpc/quick-start/", http.StatusFound)
+		if strings.Trim(req.URL.Path, "/") == "fast" {
+			http.Redirect(respw, req, "https://docs.flashbots.net/flashbots-protect/rpc/fast-mode/", http.StatusFound)
+		} else {
+			http.Redirect(respw, req, "https://docs.flashbots.net/flashbots-protect/rpc/quick-start/", http.StatusFound)
+		}
 		return
 	}
 


### PR DESCRIPTION
## Problem

Currently, both https://rpc.flashbots.net/ and https://rpc.flashbots.net/fast redirect to the [same docs page](https://docs.flashbots.net/flashbots-protect/rpc/quick-start/) although I think it's more expected to have a redirect to [fast mode related page](https://docs.flashbots.net/flashbots-protect/rpc/fast-mode) for `/fast` endpoint.

If it's an expected behaviour, you can close the PR 😄 

## Solution
```bash
➜  ~ curl -v -L localhost:9000 2>&1 | grep -i "^< location:"
< Location: https://docs.flashbots.net/flashbots-protect/rpc/quick-start/

➜  ~ curl -v -L localhost:9000/fast 2>&1 | grep -i "^< location:"
< Location: https://docs.flashbots.net/flashbots-protect/rpc/fast-mode/
```