### PR TITLE
update aztec rollup contract to be aztec connect

### DIFF
--- a/server/whitelist.go
+++ b/server/whitelist.go
@@ -19,5 +19,5 @@ func isOnFunctionWhitelist(data string) bool {
 }
 
 var allowedLargeTxTargets = map[string]bool{
-	"0x737901bea3eeb88459df9ef1be8ff3ae1b42a2ba": true, // Aztec rollup contract
+	"0xFF1F2B4ADb9dF6FC8eAFecDcbF96A2B351680455": true, // Aztec rollup contract
 }

--- a/server/whitelist.go
+++ b/server/whitelist.go
@@ -19,5 +19,5 @@ func isOnFunctionWhitelist(data string) bool {
 }
 
 var allowedLargeTxTargets = map[string]bool{
-	"0xFF1F2B4ADb9dF6FC8eAFecDcbF96A2B351680455": true, // Aztec rollup contract
+	"0xff1f2b4adb9df6fc8eafecdcbf96a2b351680455": true, // Aztec rollup contract
 }


### PR DESCRIPTION
This PR updates the Aztec rollup contract to be on the whitelist for large transactions on flashbots.