### PR TITLE
Extend sanctions checking

### DIFF
--- a/server/request_sendrawtx.go
+++ b/server/request_sendrawtx.go
@@ -98,6 +98,13 @@ func (r *RpcRequest) handle_sendRawTransaction() {
 		r.writeRpcError("blocked tx due to ofac sanctioned address", types.JsonRpcInvalidRequest)
 		return
 	}
+	isOnUkSanctionsList := isOnUKSanctionsList(r.txFrom) || isOnUKSanctionsList(r.tx.To().String())
+	r.ethSendRawTxEntry.IsOnUkSanctionsList = isOnUKSanctionsList
+	if isOnUKSanctionsList {
+		r.logger.Info("[sendRawTransaction] Blocked tx due to UK sanctioned address", "txFrom", r.txFrom, "txTo", r.tx.To().String())
+		r.writeRpcError("blocked tx due to UK sanctioned address", types.JsonRpcInvalidRequest)
+		return
+	}
 
 	// Check if transaction needs protection
 	needsProtection := r.doesTxNeedFrontrunningProtection(r.tx)

--- a/server/uksanctionsblacklist.go
+++ b/server/uksanctionsblacklist.go
@@ -1,0 +1,14 @@
+// UK Sanctions List addresses
+// https://docs.fcdo.gov.uk/docs/UK-Sanctions-List.html
+package server
+
+import "strings"
+
+var ukSanctionsBlacklist = map[string]bool{
+	"0x7ff9cfad3877f21d41da833e2f775db0569ee3d9": true,
+}
+
+func isOnUKSanctionsList(address string) bool {
+	addrs := strings.ToLower(address)
+	return ukSanctionsBlacklist[addrs]
+}

--- a/server/uksanctionsblacklist_test.go
+++ b/server/uksanctionsblacklist_test.go
@@ -1,0 +1,30 @@
+package server
+
+import "testing"
+
+func Test_isOnUKSanctionsList(t *testing.T) {
+	tests := map[string]struct {
+		address string
+		want    bool
+	}{
+		"Check different cases": {
+			address: "0X7ff9cfAD3877F21D41DA833E2F775DB0569EE3D9",
+			want:    true,
+		},
+		"Check upper cases": {
+			address: "0X7FF9CFAD3877F21D41DA833E2F775DB0569EE3D9",
+			want:    true,
+		},
+		"Check unknow": {
+			address: "0X5",
+			want:    false,
+		},
+	}
+	for testName, testCase := range tests {
+		t.Run(testName, func(t *testing.T) {
+			if got := isOnUKSanctionsList(testCase.address); got != testCase.want {
+				t.Errorf("isOnUKSanctionsList() = %v, want %v", got, testCase.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The current RPC endpoint doesn't go far enough in sanctioning bad people and bad addresses as this only covers one region of the world (USA). The world is much larger and we should account for possible sanctions in every corner of the globe and not just one country. This of course would be the most fair way of handling this so that one country doesn't receive undue preference.

I've made a start by adding the only current UK sanctioned address, seen here: https://docs.fcdo.gov.uk/docs/UK-Sanctions-List.html

I am willing to also add the same sanctions checking for other regions such as Russia, China, and North Korea (non-inclusive, just for example) if anyone is able to point me in the direction of their sanctions lists.