### PR TITLE
[fix] Implement pod draining

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@ var (
 	defaultLogJSON             = os.Getenv("LOG_JSON") == "1"
 	defaultListenAddress       = "127.0.0.1:9000"
 	defaultDrainAddress        = "127.0.0.1:9001"
+	defaultDrainSeconds        = 60
 	defaultProxyUrl            = "http://127.0.0.1:8545"
 	defaultProxyTimeoutSeconds = 10
 	defaultRelayUrl            = "https://relay.flashbots.net"
@@ -31,6 +32,7 @@ var (
 	versionPtr          = flag.Bool("version", false, "just print the program version")
 	listenAddress       = flag.String("listen", getEnvAsStrOrDefault("LISTEN_ADDR", defaultListenAddress), "Listen address")
 	drainAddress        = flag.String("drain", getEnvAsStrOrDefault("DRAIN_ADDR", defaultDrainAddress), "Drain address")
+	drainSeconds        = flag.Int("drainSeconds", getEnvAsIntOrDefault("DRAIN_SECONDS", defaultDrainSeconds), "seconds to wait for graceful shutdown")
 	proxyUrl            = flag.String("proxy", getEnvAsStrOrDefault("PROXY_URL", defaultProxyUrl), "URL for default JSON-RPC proxy target (eth node, Infura, etc.)")
 	proxyTimeoutSeconds = flag.Int("proxyTimeoutSeconds", getEnvAsIntOrDefault("PROXY_TIMEOUT_SECONDS", defaultProxyTimeoutSeconds), "proxy client timeout in seconds")
 	redisUrl            = flag.String("redis", getEnvAsStrOrDefault("REDIS_URL", defaultRedisUrl), "URL for Redis (use 'dev' to use integrated in-memory redis)")
@@ -97,6 +99,7 @@ func main() {
 	s, err := server.NewRpcEndPointServer(server.Configuration{
 		DB:                  db,
 		DrainAddress:        *drainAddress,
+		DrainSeconds:        *drainSeconds,
 		ListenAddress:       *listenAddress,
 		Logger:              logger,
 		ProxyTimeoutSeconds: *proxyTimeoutSeconds,

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/flashbots/rpc-endpoint/database"
+)
+
+type Configuration struct {
+	DB                  database.Store
+	DrainAddress        string
+	ListenAddress       string
+	Logger              log.Logger
+	ProxyTimeoutSeconds int
+	ProxyUrl            string
+	RedisUrl            string
+	RelaySigningKey     *ecdsa.PrivateKey
+	RelayUrl            string
+	Version             string
+}

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -10,6 +10,7 @@ import (
 type Configuration struct {
 	DB                  database.Store
 	DrainAddress        string
+	DrainSeconds        int
 	ListenAddress       string
 	Logger              log.Logger
 	ProxyTimeoutSeconds int

--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,7 @@ type RpcEndPointServer struct {
 	drain  *http.Server
 
 	drainAddress        string
+	drainSeconds        int
 	db                  database.Store
 	isHealthy           bool
 	listenAddress       string
@@ -75,6 +76,7 @@ func NewRpcEndPointServer(cfg Configuration) (*RpcEndPointServer, error) {
 	return &RpcEndPointServer{
 		db:                  cfg.DB,
 		drainAddress:        cfg.DrainAddress,
+		drainSeconds:        cfg.DrainSeconds,
 		isHealthy:           true,
 		listenAddress:       cfg.ListenAddress,
 		logger:              cfg.Logger,
@@ -197,7 +199,10 @@ func (s *RpcEndPointServer) handleDrain(respw http.ResponseWriter, req *http.Req
 	if s.isHealthy {
 		s.isHealthy = false
 		s.logger.Info("Server marked as unhealthy")
-		time.Sleep(60 * time.Second) // Give LB enough time to detect us unhealthy
+		// Give LB enough time to detect us unhealthy
+		time.Sleep(
+			time.Duration(s.drainSeconds) * time.Second,
+		)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -33,49 +33,56 @@ var RState *RedisState
 var FlashbotsRPC *flashbotsrpc.FlashbotsRPC
 
 type RpcEndPointServer struct {
-	logger              log.Logger
-	version             string
-	startTime           time.Time
-	listenAddress       string
-	proxyUrl            string
-	proxyTimeoutSeconds int
-	relaySigningKey     *ecdsa.PrivateKey
+	server *http.Server
+	drain  *http.Server
+
+	drainAddress        string
 	db                  database.Store
+	isHealthy           bool
+	listenAddress       string
+	logger              log.Logger
+	proxyTimeoutSeconds int
+	proxyUrl            string
+	relaySigningKey     *ecdsa.PrivateKey
+	startTime           time.Time
+	version             string
 }
 
-func NewRpcEndPointServer(logger log.Logger, version, listenAddress, relayUrl, proxyUrl string, proxyTimeoutSeconds int, relaySigningKey *ecdsa.PrivateKey, redisUrl string, db database.Store) (*RpcEndPointServer, error) {
+func NewRpcEndPointServer(cfg Configuration) (*RpcEndPointServer, error) {
 	var err error
 	if DebugDontSendTx {
-		logger.Info("DEBUG MODE: raw transactions will not be sent out!", "redisUrl", redisUrl)
+		cfg.Logger.Info("DEBUG MODE: raw transactions will not be sent out!", "redisUrl", cfg.RedisUrl)
 	}
 
-	if redisUrl == "dev" {
-		logger.Info("Using integrated in-memory Redis instance", "redisUrl", redisUrl)
+	if cfg.RedisUrl == "dev" {
+		cfg.Logger.Info("Using integrated in-memory Redis instance", "redisUrl", cfg.RedisUrl)
 		redisServer, err := miniredis.Run()
 		if err != nil {
 			return nil, err
 		}
-		redisUrl = redisServer.Addr()
+		cfg.RedisUrl = redisServer.Addr()
 	}
 	// Setup redis connection
-	logger.Info("Connecting to redis...", "redisUrl", redisUrl)
-	RState, err = NewRedisState(redisUrl)
+	cfg.Logger.Info("Connecting to redis...", "redisUrl", cfg.RedisUrl)
+	RState, err = NewRedisState(cfg.RedisUrl)
 	if err != nil {
 		return nil, errors.Wrap(err, "Redis init error")
 	}
 
-	FlashbotsRPC = flashbotsrpc.New(relayUrl)
+	FlashbotsRPC = flashbotsrpc.New(cfg.RelayUrl)
 	// FlashbotsRPC.Debug = true
 
 	return &RpcEndPointServer{
-		logger:              logger,
+		db:                  cfg.DB,
+		drainAddress:        cfg.DrainAddress,
+		isHealthy:           true,
+		listenAddress:       cfg.ListenAddress,
+		logger:              cfg.Logger,
+		proxyTimeoutSeconds: cfg.ProxyTimeoutSeconds,
+		proxyUrl:            cfg.ProxyUrl,
+		relaySigningKey:     cfg.RelaySigningKey,
 		startTime:           Now(),
-		version:             version,
-		listenAddress:       listenAddress,
-		proxyUrl:            proxyUrl,
-		proxyTimeoutSeconds: proxyTimeoutSeconds,
-		relaySigningKey:     relaySigningKey,
-		db:                  db,
+		version:             cfg.Version,
 	}, nil
 }
 
@@ -90,35 +97,79 @@ func (s *RpcEndPointServer) Start() {
 		}
 	}()
 
-	// Handler for root URL (JSON-RPC on POST, public/index.html on GET)
-	http.HandleFunc("/", s.HandleHttpRequest)
-	http.HandleFunc("/health", s.handleHealthRequest)
-	http.HandleFunc("/bundle", s.HandleBundleRequest)
-
-	server := &http.Server{
-		Addr:         s.listenAddress,
-		WriteTimeout: 30 * time.Second,
-		ReadTimeout:  30 * time.Second,
-	}
-
-	go func() {
-		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			s.logger.Error("http server failed", "error", err)
-		}
-	}()
+	s.startMainServer()
+	s.startDrainServer()
 
 	notifier := make(chan os.Signal, 1)
 	signal.Notify(notifier, os.Interrupt, syscall.SIGTERM)
 
 	<-notifier
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	s.stopDrainServer()
+	s.stopMainServer()
+}
 
-	if err := server.Shutdown(ctx); err != nil {
-		s.logger.Error("http server shutdown failed", "error", err)
+func (s *RpcEndPointServer) startMainServer() {
+	if s.server != nil {
+		panic("http server is already running")
 	}
-	s.logger.Info("http server stopped")
+	// Handler for root URL (JSON-RPC on POST, public/index.html on GET)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.HandleHttpRequest)
+	mux.HandleFunc("/health", s.handleHealthRequest)
+	mux.HandleFunc("/bundle", s.HandleBundleRequest)
+	s.server = &http.Server{
+		Addr:         s.listenAddress,
+		Handler:      mux,
+		WriteTimeout: 30 * time.Second,
+		ReadTimeout:  30 * time.Second,
+	}
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error("http server failed", "error", err)
+		}
+	}()
+}
+
+func (s *RpcEndPointServer) stopMainServer() {
+	if s.server != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.server.Shutdown(ctx); err != nil {
+			s.logger.Error("http server shutdown failed", "error", err)
+		}
+		s.logger.Info("http server stopped")
+		s.server = nil
+	}
+}
+
+func (s *RpcEndPointServer) startDrainServer() {
+	if s.drain != nil {
+		panic("drain http server is already running")
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", s.handleDrain)
+	s.drain = &http.Server{
+		Addr:    s.drainAddress,
+		Handler: mux,
+	}
+	go func() {
+		if err := s.drain.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error("drain http server failed", "error", err)
+		}
+	}()
+}
+
+func (s *RpcEndPointServer) stopDrainServer() {
+	if s.drain != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.drain.Shutdown(ctx); err != nil {
+			s.logger.Error("drain http server shutdown failed", "error", err)
+		}
+		s.logger.Info("drain http server stopped")
+		s.drain = nil
+	}
 }
 
 func (s *RpcEndPointServer) HandleHttpRequest(respw http.ResponseWriter, req *http.Request) {
@@ -142,6 +193,14 @@ func (s *RpcEndPointServer) HandleHttpRequest(respw http.ResponseWriter, req *ht
 	request.process()
 }
 
+func (s *RpcEndPointServer) handleDrain(respw http.ResponseWriter, req *http.Request) {
+	if s.isHealthy {
+		s.isHealthy = false
+		s.logger.Info("Server marked as unhealthy")
+		time.Sleep(60 * time.Second) // Give LB enough time to detect us unhealthy
+	}
+}
+
 func (s *RpcEndPointServer) handleHealthRequest(respw http.ResponseWriter, req *http.Request) {
 	res := types.HealthResponse{
 		Now:       Now(),
@@ -157,7 +216,11 @@ func (s *RpcEndPointServer) handleHealthRequest(respw http.ResponseWriter, req *
 	}
 
 	respw.Header().Set("Content-Type", "application/json")
-	respw.WriteHeader(http.StatusOK)
+	if s.isHealthy {
+		respw.WriteHeader(http.StatusOK)
+	} else {
+		respw.WriteHeader(http.StatusInternalServerError)
+	}
 	respw.Write(jsonResp)
 }
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -69,7 +69,16 @@ func testServerSetup(db database.Store) {
 	server.ProtectTxApiHost = txApiServer.URL
 
 	// Create a fresh RPC endpoint server
-	rpcServer, err := server.NewRpcEndPointServer(log.New("testlogger"), "test", "", RpcBackendServerUrl, RpcBackendServerUrl, 10, relaySigningKey, redisServer.Addr(), db)
+	rpcServer, err := server.NewRpcEndPointServer(server.Configuration{
+		DB:                  db,
+		Logger:              log.New("testlogger"),
+		ProxyTimeoutSeconds: 10,
+		ProxyUrl:            RpcBackendServerUrl,
+		RedisUrl:            redisServer.Addr(),
+		RelaySigningKey:     relaySigningKey,
+		RelayUrl:            RpcBackendServerUrl,
+		Version:             "test",
+	})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR implements separate HTTP server listening on `DRAIN_ADDR`.  When it receives HTTP GET, it will flag server as un-healthy.  From that moment on `/health` endpoint of the main HTTP server will start reporting `HTTP 500`.

If we use this in conjunction with k8s pre-stop hook, we can make sure that on updates/restarts the pod lives long enough to serve whatever requests the load-balancer would still forward to it until it detects that the server is not healthy.

For example:

```yaml
          lifecycle:
            preStop:
              httpGet:
                port: 8081
          env:
            - name: DRAIN_ADDR
              value: :8081
```