### PR TITLE
set origin as a header

### DIFF
--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -22,11 +22,12 @@ type RpcRequestHandler struct {
 	defaultProxyUrl     string
 	proxyTimeoutSeconds int
 	relaySigningKey     *ecdsa.PrivateKey
+	relayUrl            string
 	uid                 uuid.UUID
 	requestRecord       *requestRecord
 }
 
-func NewRpcRequestHandler(logger log.Logger, respw *http.ResponseWriter, req *http.Request, proxyUrl string, proxyTimeoutSeconds int, relaySigningKey *ecdsa.PrivateKey, db database.Store) *RpcRequestHandler {
+func NewRpcRequestHandler(logger log.Logger, respw *http.ResponseWriter, req *http.Request, proxyUrl string, proxyTimeoutSeconds int, relaySigningKey *ecdsa.PrivateKey, relayUrl string, db database.Store) *RpcRequestHandler {
 	return &RpcRequestHandler{
 		logger:              logger,
 		respw:               respw,
@@ -35,6 +36,7 @@ func NewRpcRequestHandler(logger log.Logger, respw *http.ResponseWriter, req *ht
 		defaultProxyUrl:     proxyUrl,
 		proxyTimeoutSeconds: proxyTimeoutSeconds,
 		relaySigningKey:     relaySigningKey,
+		relayUrl:            relayUrl,
 		uid:                 uuid.New(),
 		requestRecord:       NewRequestRecord(db),
 	}
@@ -112,7 +114,7 @@ func (r *RpcRequestHandler) processRequest(client RPCProxyClient, jsonReq *types
 		entry = r.requestRecord.AddEthSendRawTxEntry(uuid.New())
 	}
 	// Handle single request
-	rpcReq := NewRpcRequest(r.logger, client, jsonReq, r.relaySigningKey, origin, referer, isWhitehatBundleCollection, whitehatBundleId, entry, urlParams)
+	rpcReq := NewRpcRequest(r.logger, client, jsonReq, r.relaySigningKey, r.relayUrl, origin, referer, isWhitehatBundleCollection, whitehatBundleId, entry, urlParams)
 	res := rpcReq.ProcessRequest()
 	// Write response
 	r._writeRpcResponse(res)

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/alicebob/miniredis"
 	"github.com/flashbots/rpc-endpoint/types"
-	"github.com/metachris/flashbotsrpc"
 	"github.com/pkg/errors"
 )
 
@@ -30,8 +29,6 @@ var DebugDontSendTx = os.Getenv("DEBUG_DONT_SEND_RAWTX") != ""
 
 // Metamask fix helper
 var RState *RedisState
-
-var FlashbotsRPC *flashbotsrpc.FlashbotsRPC
 
 type RpcEndPointServer struct {
 	server *http.Server
@@ -47,6 +44,7 @@ type RpcEndPointServer struct {
 	proxyTimeoutSeconds int
 	proxyUrl            string
 	relaySigningKey     *ecdsa.PrivateKey
+	relayUrl            string
 	startTime           time.Time
 	version             string
 }
@@ -72,9 +70,6 @@ func NewRpcEndPointServer(cfg Configuration) (*RpcEndPointServer, error) {
 		return nil, errors.Wrap(err, "Redis init error")
 	}
 
-	FlashbotsRPC = flashbotsrpc.New(cfg.RelayUrl)
-	// FlashbotsRPC.Debug = true
-
 	return &RpcEndPointServer{
 		db:                  cfg.DB,
 		drainAddress:        cfg.DrainAddress,
@@ -85,6 +80,7 @@ func NewRpcEndPointServer(cfg Configuration) (*RpcEndPointServer, error) {
 		proxyTimeoutSeconds: cfg.ProxyTimeoutSeconds,
 		proxyUrl:            cfg.ProxyUrl,
 		relaySigningKey:     cfg.RelaySigningKey,
+		relayUrl:            cfg.RelayUrl,
 		startTime:           Now(),
 		version:             cfg.Version,
 	}, nil
@@ -193,7 +189,7 @@ func (s *RpcEndPointServer) HandleHttpRequest(respw http.ResponseWriter, req *ht
 		return
 	}
 
-	request := NewRpcRequestHandler(s.logger, &respw, req, s.proxyUrl, s.proxyTimeoutSeconds, s.relaySigningKey, s.db)
+	request := NewRpcRequestHandler(s.logger, &respw, req, s.proxyUrl, s.proxyTimeoutSeconds, s.relaySigningKey, s.relayUrl, s.db)
 	request.process()
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -109,7 +109,6 @@ type BundleResponse struct {
 
 type SendPrivateTxRequestWithPreferences struct {
 	flashbotsrpc.FlashbotsSendPrivateTransactionRequest
-	OriginID    string                `json:"originId,omitempty"`
 	Preferences *PrivateTxPreferences `json:"preferences,omitempty"`
 }
 


### PR DESCRIPTION
## 📝 Summary

Adds support for "x-flashbots-origin" header on the relay.

## ⛱ Motivation and Context

x-flashbots-origin is a new header on the relay that lets user to specify order flow origin

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
