### PR TITLE
Use special logs only in the default hint

### DIFF
--- a/server/url_params.go
+++ b/server/url_params.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	DefaultAuctionHint = []string{"hash"}
+	DefaultAuctionHint = []string{"hash", "special_logs"}
 
 	ErrEmptyHintQuery                      = errors.New("Hint query must be non-empty if set.")
 	ErrEmptyTargetBuilderQuery             = errors.New("Target builder query must be non-empty if set.")
@@ -54,8 +54,6 @@ func ExtractParametersFromUrl(url *url.URL) (params URLParameters, err error) {
 	} else {
 		hint = DefaultAuctionHint
 	}
-	// append special logs hidden hint, so we can leak swap logs for protect txs
-	hint = append(hint, "special_logs")
 	params.pref.Hints = hint
 
 	originIdQuery, ok := url.Query()["originId"]

--- a/server/url_params_test.go
+++ b/server/url_params_test.go
@@ -23,10 +23,19 @@ func TestExtractAuctionPreferenceFromUrl(t *testing.T) {
 			},
 			err: nil,
 		},
+		"only hash hint": {
+			url: "https://rpc.flashbots.net?hint=hash",
+			want: URLParameters{
+				pref:       types.TxPrivacyPreferences{Hints: []string{"hash"}},
+				prefWasSet: true,
+				originId:   "",
+			},
+			err: nil,
+		},
 		"correct hint preference": {
 			url: "https://rpc.flashbots.net?hint=contract_address&hint=function_selector&hint=logs&hint=calldata&hint=hash",
 			want: URLParameters{
-				pref:       types.TxPrivacyPreferences{Hints: []string{"contract_address", "function_selector", "logs", "calldata", "hash", "special_logs"}},
+				pref:       types.TxPrivacyPreferences{Hints: []string{"contract_address", "function_selector", "logs", "calldata", "hash"}},
 				prefWasSet: true,
 				originId:   "",
 			},


### PR DESCRIPTION
## 📝 Summary

special_logs hints is no longer appended by default

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
