### PR TITLE
Update URL for rpc.flashbots.net redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We're open to new ways of evaluating what needs frontrunning protection and welc
 
 ## Usage
 
-To send your transactions through the Flashbots Protect RPC please refer to the [quick-start guide](https://docs.flashbots.net/flashbots-protect/rpc/quick-start/).
+To send your transactions through the Flashbots Protect RPC please refer to the [quick-start guide](https://docs.flashbots.net/flashbots-protect/overview).
 
 To run the server, run the following command:
 

--- a/server/server.go
+++ b/server/server.go
@@ -177,9 +177,9 @@ func (s *RpcEndPointServer) HandleHttpRequest(respw http.ResponseWriter, req *ht
 
 	if req.Method == http.MethodGet {
 		if strings.Trim(req.URL.Path, "/") == "fast" {
-			http.Redirect(respw, req, "https://docs.flashbots.net/flashbots-protect/rpc/fast-mode/", http.StatusFound)
+			http.Redirect(respw, req, "https://docs.flashbots.net/flashbots-protect/overview", http.StatusFound)
 		} else {
-			http.Redirect(respw, req, "https://docs.flashbots.net/flashbots-protect/rpc/quick-start/", http.StatusFound)
+			http.Redirect(respw, req, "https://docs.flashbots.net/flashbots-protect/overview", http.StatusFound)
 		}
 		return
 	}


### PR DESCRIPTION
## 📝 Summary

We changed the docs. We need to update the URL that going to rpc.flashbots.net redirects to. I changed the URL in a few places.

## ⛱ Motivation and Context

We changed the docs. We need to update the URL that going to rpc.flashbots.net redirects to.

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
