### PR TITLE
Fast mode

### DIFF
--- a/adapters/webfile/fetcher.go
+++ b/adapters/webfile/fetcher.go
@@ -1,0 +1,42 @@
+package webfile
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+var ErrRequest = fmt.Errorf("request failed")
+
+//https://raw.githubusercontent.com/flashbots/dowg/main/builder-registrations.json
+
+type Fetcher struct {
+	url string
+	cl  http.Client
+}
+
+func NewFetcher(url string) *Fetcher {
+	return &Fetcher{url: url, cl: http.Client{}}
+}
+
+func (f *Fetcher) Fetch(ctx context.Context) ([]byte, error) {
+	//execute http request and load bytes
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, f.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := f.cl.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	bts, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("err: %w status code %d", ErrRequest, resp.StatusCode)
+	}
+	return bts, nil
+}

--- a/adapters/webfile/fetcher_test.go
+++ b/adapters/webfile/fetcher_test.go
@@ -1,0 +1,21 @@
+package webfile
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestFetch(t *testing.T) {
+	f := Fetcher{
+		url: "https://raw.githubusercontent.com/flashbots/dowg/main/builder-registrations.json",
+		cl:  http.Client{},
+	}
+	bts, err := f.Fetch(context.Background())
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(bts))
+}

--- a/application/builder_info.go
+++ b/application/builder_info.go
@@ -1,0 +1,75 @@
+package application
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type BuilderInfo struct {
+	Name          string   `json:"name"`
+	RPC           string   `json:"rpc"`
+	SupportedApis []string `json:"supported-apis"`
+}
+type Fetcher interface {
+	Fetch(ctx context.Context) ([]byte, error)
+}
+type BuilderInfoService struct {
+	fetcher      Fetcher
+	builderInfos []BuilderInfo
+}
+
+func StartBuilderInfoService(ctx context.Context, fetcher Fetcher, fetchInterval time.Duration) (*BuilderInfoService, error) {
+	bis := BuilderInfoService{
+		fetcher: fetcher,
+	}
+	if fetcher != nil {
+		err := bis.fetchBuilderInfo(ctx)
+		if err != nil {
+			return nil, err
+		}
+		go bis.syncLoop(fetchInterval)
+
+	}
+	return &bis, nil
+}
+func (bis *BuilderInfoService) Builders() []BuilderInfo {
+	return bis.builderInfos
+}
+
+func (bis *BuilderInfoService) BuilderNames() []string {
+	var names = make([]string, 0, len(bis.builderInfos))
+	for _, builderInfo := range bis.builderInfos {
+		names = append(names, builderInfo.Name)
+	}
+	return names
+}
+
+func (bis *BuilderInfoService) syncLoop(fetchInterval time.Duration) {
+	ticker := time.NewTicker(fetchInterval)
+	for range ticker.C {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		err := bis.fetchBuilderInfo(ctx)
+		if err != nil {
+			//TODO: probably panic on multiple consequent errors, though it's not critical in nature
+			log.Error("failed to fetch builder info", "err", err)
+		}
+		cancel()
+	}
+}
+
+func (bis *BuilderInfoService) fetchBuilderInfo(ctx context.Context) error {
+	bts, err := bis.fetcher.Fetch(ctx)
+	if err != nil {
+		return err
+	}
+	var builderInfos []BuilderInfo
+	err = json.Unmarshal(bts, &builderInfos)
+	if err != nil {
+		return err
+	}
+	bis.builderInfos = builderInfos
+	return nil
+}

--- a/application/builder_info.go
+++ b/application/builder_info.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -42,7 +43,7 @@ func (bis *BuilderInfoService) Builders() []BuilderInfo {
 func (bis *BuilderInfoService) BuilderNames() []string {
 	var names = make([]string, 0, len(bis.builderInfos))
 	for _, builderInfo := range bis.builderInfos {
-		names = append(names, builderInfo.Name)
+		names = append(names, strings.ToLower(builderInfo.Name))
 	}
 	return names
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,31 +17,34 @@ var (
 	version = "dev" // is set during build process
 
 	// defaults
-	defaultDebug               = os.Getenv("DEBUG") == "1"
-	defaultLogJSON             = os.Getenv("LOG_JSON") == "1"
-	defaultListenAddress       = "127.0.0.1:9000"
-	defaultDrainAddress        = "127.0.0.1:9001"
-	defaultDrainSeconds        = 60
-	defaultProxyUrl            = "http://127.0.0.1:8545"
-	defaultProxyTimeoutSeconds = 10
-	defaultRelayUrl            = "https://relay.flashbots.net"
-	defaultRedisUrl            = "localhost:6379"
-	defaultServiceName         = os.Getenv("SERVICE_NAME")
+	defaultDebug                    = os.Getenv("DEBUG") == "1"
+	defaultLogJSON                  = os.Getenv("LOG_JSON") == "1"
+	defaultListenAddress            = "127.0.0.1:9000"
+	defaultDrainAddress             = "127.0.0.1:9001"
+	defaultDrainSeconds             = 60
+	defaultProxyUrl                 = "http://127.0.0.1:8545"
+	defaultProxyTimeoutSeconds      = 10
+	defaultRelayUrl                 = "https://relay.flashbots.net"
+	defaultRedisUrl                 = "localhost:6379"
+	defaultServiceName              = os.Getenv("SERVICE_NAME")
+	defaultFetchInfoIntervalSeconds = 600
 
 	// cli flags
-	versionPtr          = flag.Bool("version", false, "just print the program version")
-	listenAddress       = flag.String("listen", getEnvAsStrOrDefault("LISTEN_ADDR", defaultListenAddress), "Listen address")
-	drainAddress        = flag.String("drain", getEnvAsStrOrDefault("DRAIN_ADDR", defaultDrainAddress), "Drain address")
-	drainSeconds        = flag.Int("drainSeconds", getEnvAsIntOrDefault("DRAIN_SECONDS", defaultDrainSeconds), "seconds to wait for graceful shutdown")
-	proxyUrl            = flag.String("proxy", getEnvAsStrOrDefault("PROXY_URL", defaultProxyUrl), "URL for default JSON-RPC proxy target (eth node, Infura, etc.)")
-	proxyTimeoutSeconds = flag.Int("proxyTimeoutSeconds", getEnvAsIntOrDefault("PROXY_TIMEOUT_SECONDS", defaultProxyTimeoutSeconds), "proxy client timeout in seconds")
-	redisUrl            = flag.String("redis", getEnvAsStrOrDefault("REDIS_URL", defaultRedisUrl), "URL for Redis (use 'dev' to use integrated in-memory redis)")
-	relayUrl            = flag.String("relayUrl", getEnvAsStrOrDefault("RELAY_URL", defaultRelayUrl), "URL for relay")
-	relaySigningKey     = flag.String("signingKey", os.Getenv("RELAY_SIGNING_KEY"), "Signing key for relay requests")
-	psqlDsn             = flag.String("psql", os.Getenv("POSTGRES_DSN"), "Postgres DSN")
-	debugPtr            = flag.Bool("debug", defaultDebug, "print debug output")
-	logJSONPtr          = flag.Bool("logJSON", defaultLogJSON, "log in JSON")
-	serviceName         = flag.String("serviceName", defaultServiceName, "name of the service which will be used in the logs")
+	versionPtr           = flag.Bool("version", false, "just print the program version")
+	listenAddress        = flag.String("listen", getEnvAsStrOrDefault("LISTEN_ADDR", defaultListenAddress), "Listen address")
+	drainAddress         = flag.String("drain", getEnvAsStrOrDefault("DRAIN_ADDR", defaultDrainAddress), "Drain address")
+	drainSeconds         = flag.Int("drainSeconds", getEnvAsIntOrDefault("DRAIN_SECONDS", defaultDrainSeconds), "seconds to wait for graceful shutdown")
+	fetchIntervalSeconds = flag.Int("fetchIntervalSeconds", getEnvAsIntOrDefault("FETCH_INFO_INTERVAL_SECONDS", defaultFetchInfoIntervalSeconds), "seconds between builder info fetches")
+	builderInfoSource    = flag.String("builderInfoSource", getEnvAsStrOrDefault("BUILDER_INFO_SOURCE", ""), "URL for json source of actual builder info")
+	proxyUrl             = flag.String("proxy", getEnvAsStrOrDefault("PROXY_URL", defaultProxyUrl), "URL for default JSON-RPC proxy target (eth node, Infura, etc.)")
+	proxyTimeoutSeconds  = flag.Int("proxyTimeoutSeconds", getEnvAsIntOrDefault("PROXY_TIMEOUT_SECONDS", defaultProxyTimeoutSeconds), "proxy client timeout in seconds")
+	redisUrl             = flag.String("redis", getEnvAsStrOrDefault("REDIS_URL", defaultRedisUrl), "URL for Redis (use 'dev' to use integrated in-memory redis)")
+	relayUrl             = flag.String("relayUrl", getEnvAsStrOrDefault("RELAY_URL", defaultRelayUrl), "URL for relay")
+	relaySigningKey      = flag.String("signingKey", os.Getenv("RELAY_SIGNING_KEY"), "Signing key for relay requests")
+	psqlDsn              = flag.String("psql", os.Getenv("POSTGRES_DSN"), "Postgres DSN")
+	debugPtr             = flag.Bool("debug", defaultDebug, "print debug output")
+	logJSONPtr           = flag.Bool("logJSON", defaultLogJSON, "log in JSON")
+	serviceName          = flag.String("serviceName", defaultServiceName, "name of the service which will be used in the logs")
 )
 
 func main() {
@@ -108,6 +111,8 @@ func main() {
 		RelaySigningKey:     key,
 		RelayUrl:            *relayUrl,
 		Version:             version,
+		BuilderInfoSource:   *builderInfoSource,
+		FetchInfoInterval:   *fetchIntervalSeconds,
 	})
 	if err != nil {
 		logger.Crit("Server init error", "error", err)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -19,4 +19,6 @@ type Configuration struct {
 	RelaySigningKey     *ecdsa.PrivateKey
 	RelayUrl            string
 	Version             string
+	BuilderInfoSource   string
+	FetchInfoInterval   int
 }

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -25,9 +25,10 @@ type RpcRequestHandler struct {
 	relayUrl            string
 	uid                 uuid.UUID
 	requestRecord       *requestRecord
+	builderNames        []string
 }
 
-func NewRpcRequestHandler(logger log.Logger, respw *http.ResponseWriter, req *http.Request, proxyUrl string, proxyTimeoutSeconds int, relaySigningKey *ecdsa.PrivateKey, relayUrl string, db database.Store) *RpcRequestHandler {
+func NewRpcRequestHandler(logger log.Logger, respw *http.ResponseWriter, req *http.Request, proxyUrl string, proxyTimeoutSeconds int, relaySigningKey *ecdsa.PrivateKey, relayUrl string, db database.Store, builderNames []string) *RpcRequestHandler {
 	return &RpcRequestHandler{
 		logger:              logger,
 		respw:               respw,
@@ -39,6 +40,7 @@ func NewRpcRequestHandler(logger log.Logger, respw *http.ResponseWriter, req *ht
 		relayUrl:            relayUrl,
 		uid:                 uuid.New(),
 		requestRecord:       NewRequestRecord(db),
+		builderNames:        builderNames,
 	}
 }
 
@@ -96,7 +98,7 @@ func (r *RpcRequestHandler) process() {
 	}
 
 	// mev-share parameters
-	urlParams, err := ExtractParametersFromUrl(r.req.URL)
+	urlParams, err := ExtractParametersFromUrl(r.req.URL, r.builderNames)
 	if err != nil {
 		r.logger.Warn("[process] Invalid auction preference", "error", err)
 		res := AuctionPreferenceErrorToJSONRPCResponse(jsonReq, err)

--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -253,6 +253,22 @@ func (r *RpcRequest) sendTxToRelay() {
 	}
 
 	sendPrivateTxArgs := types.SendPrivateTxRequestWithPreferences{}
+	if r.urlParams.fast {
+		if len(sendPrivateTxArgs.Preferences.Validity.Refund) == 0 {
+			addr, err := GetSenderAddressFromTx(r.tx)
+			if err != nil {
+				r.logger.Error("[sendTxToRelay] GetSenderAddressFromTx failed", "error", err)
+				r.writeRpcError(err.Error(), types.JsonRpcInternalError)
+				return
+			}
+			sendPrivateTxArgs.Preferences.Validity.Refund = []types.RefundConfig{
+				{
+					Address: addr,
+					Percent: 50,
+				},
+			}
+		}
+	}
 	sendPrivateTxArgs.Tx = r.rawTxHex
 	sendPrivateTxArgs.Preferences = &r.urlParams.pref
 

--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -253,6 +253,8 @@ func (r *RpcRequest) sendTxToRelay() {
 	}
 
 	sendPrivateTxArgs := types.SendPrivateTxRequestWithPreferences{}
+	sendPrivateTxArgs.Tx = r.rawTxHex
+	sendPrivateTxArgs.Preferences = &r.urlParams.pref
 	if r.urlParams.fast {
 		if len(sendPrivateTxArgs.Preferences.Validity.Refund) == 0 {
 			addr, err := GetSenderAddressFromTx(r.tx)
@@ -269,8 +271,6 @@ func (r *RpcRequest) sendTxToRelay() {
 			}
 		}
 	}
-	sendPrivateTxArgs.Tx = r.rawTxHex
-	sendPrivateTxArgs.Preferences = &r.urlParams.pref
 
 	fbRpc := flashbotsrpc.New(r.relayUrl, func(rpc *flashbotsrpc.FlashbotsRPC) {
 		if r.urlParams.originId != "" {

--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -277,7 +277,7 @@ func (r *RpcRequest) sendTxToRelay() {
 			rpc.Headers["X-Flashbots-Origin"] = r.urlParams.originId
 		}
 	})
-
+	r.logger.Info("[sendTxToRelay] sending transaction", "builders count", len(sendPrivateTxArgs.Preferences.Privacy.Builders), "is_fast", r.urlParams.fast)
 	_, err = fbRpc.CallWithFlashbotsSignature("eth_sendPrivateTransaction", r.relaySigningKey, sendPrivateTxArgs)
 	if err != nil {
 		if errors.Is(err, flashbotsrpc.ErrRelayErrorResponse) {

--- a/server/util.go
+++ b/server/util.go
@@ -49,6 +49,14 @@ func GetTx(rawTxHex string) (*ethtypes.Transaction, error) {
 	return tx, nil
 }
 
+func GetSenderAddressFromTx(tx *ethtypes.Transaction) (common.Address, error) {
+	signer := ethtypes.LatestSignerForChainID(tx.ChainId())
+	sender, err := ethtypes.Sender(signer, tx)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return sender, nil
+}
 func GetSenderFromTx(tx *ethtypes.Transaction) (string, error) {
 	signer := ethtypes.LatestSignerForChainID(tx.ChainId())
 	sender, err := ethtypes.Sender(signer, tx)


### PR DESCRIPTION
## 📝 Summary

Implementing `/fast` rpc endpoint with preset configuration of builders used and refund

## ⛱ Motivation and Context

Our private transactions take a lot of time to land, we want to provide useful alternatives for users

## 📚 References


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
