### PR TITLE
make URL parameters case-insensitive

### DIFF
--- a/server/url_params_test.go
+++ b/server/url_params_test.go
@@ -80,6 +80,30 @@ func TestExtractAuctionPreferenceFromUrl(t *testing.T) {
 			},
 			err: nil,
 		},
+		"origin id common spelling 1": {
+			url: "https://rpc.flashbots.net?originid=123",
+			want: URLParameters{
+				pref: types.PrivateTxPreferences{
+					Privacy:  types.TxPrivacyPreferences{Hints: []string{"hash", "special_logs"}},
+					Validity: types.TxValidityPreferences{},
+				},
+				prefWasSet: false,
+				originId:   "123",
+			},
+			err: nil,
+		},
+		"origin id common spelling 2": {
+			url: "https://rpc.flashbots.net?originID=123",
+			want: URLParameters{
+				pref: types.PrivateTxPreferences{
+					Privacy:  types.TxPrivacyPreferences{Hints: []string{"hash", "special_logs"}},
+					Validity: types.TxValidityPreferences{},
+				},
+				prefWasSet: false,
+				originId:   "123",
+			},
+			err: nil,
+		},
 		"target builder": {
 			url: "https://rpc.flashbots.net?builder=builder1&builder=builder2",
 			want: URLParameters{


### PR DESCRIPTION
## 📝 Summary

This PR makes RPC URL parameter case-insensitive.

## ⛱ Motivation and Context

We had had multiple instances where clients who claimed to have added `originId` parameters but failed to appear in our DB.

It turns out that many of them simply spelled it wrong, like `orignid` instead of `originId`.

This PR makes the RPC more robust to this type of error.

## 📚 References

None. Mostly observation of clients using `originId` with wrong cases.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
