### PR TITLE
Log request url for eth_sendRawTransaction

### DIFF
--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -134,7 +134,7 @@ func (r *RpcRequestHandler) processRequest(client RPCProxyClient, jsonReq *types
 	if jsonReq.Method == "eth_sendRawTransaction" {
 		entry = r.requestRecord.AddEthSendRawTxEntry(uuid.New())
 		// log the full url for debugging
-		r.logger.Info("[processRequest] Request URL", "url", reqURL)
+		r.logger.Info("[processRequest] eth_sendRawTransaction request URL", "url", reqURL)
 	}
 	// Handle single request
 	rpcReq := NewRpcRequest(r.logger, client, jsonReq, r.relaySigningKey, r.relayUrl, origin, referer, isWhitehatBundleCollection, whitehatBundleId, entry, urlParams, r.chainID, r.rpcCache)

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -125,14 +125,16 @@ func (r *RpcRequestHandler) process() {
 	r.logger = r.logger.New("rpc_method", jsonReq.Method)
 
 	// Process single request
-	r.processRequest(client, jsonReq, origin, referer, isWhitehatBundleCollection, whitehatBundleId, urlParams)
+	r.processRequest(client, jsonReq, origin, referer, isWhitehatBundleCollection, whitehatBundleId, urlParams, r.req.URL.String())
 }
 
 // processRequest handles single request
-func (r *RpcRequestHandler) processRequest(client RPCProxyClient, jsonReq *types.JsonRpcRequest, origin, referer string, isWhitehatBundleCollection bool, whitehatBundleId string, urlParams URLParameters) {
+func (r *RpcRequestHandler) processRequest(client RPCProxyClient, jsonReq *types.JsonRpcRequest, origin, referer string, isWhitehatBundleCollection bool, whitehatBundleId string, urlParams URLParameters, reqURL string) {
 	var entry *database.EthSendRawTxEntry
 	if jsonReq.Method == "eth_sendRawTransaction" {
 		entry = r.requestRecord.AddEthSendRawTxEntry(uuid.New())
+		// log the full url for debugging
+		r.logger.Info("[processRequest] Request URL", "url", reqURL)
 	}
 	// Handle single request
 	rpcReq := NewRpcRequest(r.logger, client, jsonReq, r.relaySigningKey, r.relayUrl, origin, referer, isWhitehatBundleCollection, whitehatBundleId, entry, urlParams, r.chainID, r.rpcCache)
@@ -149,7 +151,6 @@ func (r *RpcRequestHandler) finishRequest() {
 		if err := r.requestRecord.SaveRecord(); err != nil {
 			log.Error("saveRecord failed", "requestId", r.requestRecord.requestEntry.Id, "error", err, "requestId", r.uid)
 		}
-
 	}()
 	r.logger.Info("Request finished", "duration", reqDuration.Seconds())
 }


### PR DESCRIPTION
## 📝 Summary

Log request url for eth_sendRawTransaction

## ⛱ Motivation and Context

Clients have been quite error prone when it comes to setting URL parameters. Currently there isn't one source of truth we can check as we don't log or record in DB the actual URL used by user. Having logging of the exact URL used would greatly facilitate debugging.

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
