### PR TITLE
feat(blobs): Allow blobs (which are by definition > 128KB)

### DIFF
--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -19,8 +19,9 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
-	"github.com/flashbots/rpc-endpoint/types"
 	"github.com/metachris/flashbotsrpc"
+
+	"github.com/flashbots/rpc-endpoint/types"
 )
 
 type RpcRequest struct {
@@ -251,9 +252,9 @@ func (r *RpcRequest) sendTxToRelay() {
 
 	go RState.SetSenderMaxNonce(r.txFrom, r.tx.Nonce())
 
-	// only allow large transactions to certain addresses - default max tx size is 128KB
+	// only allow large non-blob transactions to certain addresses - default max tx size is 128KB
 	// https://github.com/ethereum/go-ethereum/blob/master/core/tx_pool.go#L53
-	if r.tx.Size() > 131072 {
+	if r.tx.Type() != ethtypes.BlobTxType && r.tx.Size() > 131072 {
 		if r.tx.To() == nil {
 			r.logger.Error("[sendTxToRelay] large tx not allowed to target null", "tx", txHash)
 			r.writeRpcError("invalid target for large tx", types.JsonRpcInternalError)


### PR DESCRIPTION
## 📝 Summary

Currently we are blocking all tx over 128KB, which blocks blob txs.

## ⛱ Motivation and Context

Arbitrum might want to send blob txs to protect to skip the public mempool: https://flashbots.slack.com/archives/C0689NRL552/p1719345980974439

## 📚 References

Before:

```
> go run cmd/blob-sender/main.go -r https://rpc-holesky.flashbots.net --random-privkey --to 0x4bE0Cd2553356b4ABb8b6a1882325dAbC8d3013D -b "0xdeadbeef"

ERRO[0000] Error while sending transaction: invalid target for large tx  client="https://rpc-holesky.flashbots.net"
```

After:

```
> go run cmd/blob-sender/main.go -r https://rpc-holesky.flashbots.net --random-privkey --to 0x4bE0Cd2553356b4ABb8b6a1882325dAbC8d3013D -b "0xdeadbeef"
TX 1: 0x77c3481cbacdd3e463aa14e79153c2cf2f6bd66981fd99ab74b48298aca2d136
```

```
INFO [06-25|22:12:41.952] [sendRawTransaction] sending raw transaction uid=39a86cd3-12fa-4ae7-8096-ca266135ece6 rpc_method=eth_sendRawTransaction txHash=0x77c3481cbacdd3
INFO [06-25|22:12:41.957] [sendTxToRelay] sending transaction to relay uid=39a86cd3-12fa-4ae7-8096-ca266135ece6 rpc_method=eth_sendRawTransaction txHash=0x77c3481cbacdd3
INFO [06-25|22:12:42.015] [sendTxToRelay] sending transaction      uid=39a86cd3-12fa-4ae7-8096-ca266135ece6 rpc_method=eth_sendRawTransaction txHash=0x77c3481cbacdd3e463
INFO [06-25|22:12:43.498] [sendTxToRelay] Sent                     uid=39a86cd3-12fa-4ae7-8096-ca266135ece6 rpc_method=eth_sendRawTransaction txHash=0x77c3481cbacdd3e463
INFO [06-25|22:12:43.498] Request finished                         uid=39a86cd3-12fa-4ae7-8096-ca266135ece6 rpc_method=eth_sendRawTransaction duration=1.751
```

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
