### PR TITLE
fix(errorhandling): Update to flashbotsrpc v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.3.0
 	github.com/lib/pq v1.10.7
-	github.com/metachris/flashbotsrpc v0.5.0
+	github.com/metachris/flashbotsrpc v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4
 github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
-github.com/metachris/flashbotsrpc v0.5.0 h1:5OLpm6+6n4kXxeh3TZBeSj0PQWDxqUsOFwy7xertXQQ=
-github.com/metachris/flashbotsrpc v0.5.0/go.mod h1:UrS249kKA1PK27sf12M6tUxo/M4ayfFrBk7IMFY1TNw=
+github.com/metachris/flashbotsrpc v0.7.0 h1:DFpWWgaKE1hLARb5yNvKAiD5pb/VyGU4jrjhTH62ltQ=
+github.com/metachris/flashbotsrpc v0.7.0/go.mod h1:UrS249kKA1PK27sf12M6tUxo/M4ayfFrBk7IMFY1TNw=
 github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqkyU72HC5wJ4RlU=
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=


### PR DESCRIPTION
## 📝 Summary

Update `rpc-endpoint` to use `flashbotsrpc v0.7.0` which includes (https://github.com/metachris/flashbotsrpc/pull/28) which now allows `RpcRequest.sendTxToRelay()` to correctly handle 500 errors from the `bundle-relay-api` API Gateway and return an error to the user (instead of previously where we erroneously implied to the user we submitted their tx by returning the tx hash).

## ⛱ Motivation and Context

- https://linear.app/flashbots/issue/L1BB-112/test-case-with-a-server-call-that-returns-a-500-error-and-expects-an
- https://flashbots.slack.com/archives/C06Q2TRR2LE/p1719393009927729

![image](https://github.com/flashbots/rpc-endpoint/assets/53520/8d738afc-97b4-4485-8fdc-22ced9f09d1d)


## 📚 References

- https://github.com/metachris/flashbotsrpc/pull/28

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
