### PR TITLE
feat(debug): Log a privacy preserving hash of IP and UserAgent to assist in rate limiting debugging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/alicebob/miniredis v2.5.0+incompatible
+	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/ethereum/go-ethereum v1.13.11
 	github.com/go-redis/redis/v8 v8.11.5
 	github.com/google/uuid v1.3.0
@@ -17,7 +18,6 @@ require (
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/consensys/bavard v0.1.13 // indirect
 	github.com/consensys/gnark-crypto v0.12.1 // indirect
 	github.com/crate-crypto/go-kzg-4844 v0.7.0 // indirect

--- a/server/fingerprint.go
+++ b/server/fingerprint.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+type Fingerprint uint64
+
+// FingerprintFromRequest returns a fingerprint for the request based on the X-Forwarded-For header
+// and a salted timestamp.  The fingerprint is used to identify unique users sessions
+// over a short period of time, and thus can be used as a key for rate limiting.
+func FingerprintFromRequest(req *http.Request, at time.Time) (Fingerprint, error) {
+	// X-Forwarded-For header contains a comma-separated list of IP addresses when
+	// the request has been forwarded through multiple proxies.  For example:
+	//
+	// X-Forwarded-For: 2600:8802:4700:bee:d13c:c7fb:8e0f:84ff, 172.70.210.100
+	xff, err := getXForwardedForIP(req)
+	if err != nil {
+		return 0, err
+	}
+	// We considered adding the User-Agent header to the fingerprint, but decided
+	// against it because it would make the fingerprint gameable.  Instead, we
+	// will salt the fingerprint with the current timestamp rounded to the
+	// latest hour. This will make sure fingerprints rotate every hour so we
+	// cannot reasonably track user behavior over time.
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	currentHour := at.Truncate(time.Hour)
+	fingerprintPreimage := fmt.Sprintf("XFF:%s|SALT:%d", xff, currentHour.Unix())
+	return Fingerprint(xxhash.Sum64String(fingerprintPreimage)), nil
+}
+
+func (f Fingerprint) ToIPv6() net.IP {
+	// We'll generate a "fake" IPv6 address based on the fingerprint
+	// We'll use the RFC 3849 documentation prefix (2001:DB8::/32) for this.
+	// https://datatracker.ietf.org/doc/html/rfc3849
+	addr := [16]byte{
+		0:  0x20,
+		1:  0x01,
+		2:  0x0d,
+		3:  0xb8,
+		8:  byte(f >> 56),
+		9:  byte(f >> 48),
+		10: byte(f >> 40),
+		11: byte(f >> 32),
+		12: byte(f >> 24),
+		13: byte(f >> 16),
+		14: byte(f >> 8),
+		15: byte(f),
+	}
+	return addr[:]
+}
+
+func getXForwardedForIP(r *http.Request) (string, error) {
+	// gets the left-most non-private IP in the X-Forwarded-For header
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return "", fmt.Errorf("no X-Forwarded-For header")
+	}
+	ips := strings.Split(xff, ",")
+	for _, ip := range ips {
+		if !isPrivateIP(ip) {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("no non-private IP in X-Forwarded-For header")
+}
+
+func isPrivateIP(ip string) bool {
+	// compare ip to RFC-1918 known private IP ranges
+	// https://en.wikipedia.org/wiki/Private_network
+	ipAddr := net.ParseIP(ip)
+	if ipAddr == nil {
+		return false
+	}
+
+	for _, cidr := range cidrs {
+		if cidr.Contains(ipAddr) {
+			return true
+		}
+	}
+	return false
+}
+
+// Taken from https://github.com/tomasen/realip/blob/master/realip.go
+// MIT Licensed, Copyright (c) 2018 SHEN SHENG
+var cidrs []*net.IPNet
+
+func init() {
+	maxCidrBlocks := []string{
+		"127.0.0.1/8",    // localhost
+		"10.0.0.0/8",     // 24-bit block
+		"172.16.0.0/12",  // 20-bit block
+		"192.168.0.0/16", // 16-bit block
+		"169.254.0.0/16", // link local address
+		"::1/128",        // localhost IPv6
+		"fc00::/7",       // unique local address IPv6
+		"fe80::/10",      // link local address IPv6
+	}
+
+	cidrs = make([]*net.IPNet, len(maxCidrBlocks))
+	for i, maxCidrBlock := range maxCidrBlocks {
+		_, cidr, _ := net.ParseCIDR(maxCidrBlock)
+		cidrs[i] = cidr
+	}
+}

--- a/server/fingerprint_test.go
+++ b/server/fingerprint_test.go
@@ -1,0 +1,28 @@
+package server_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/flashbots/rpc-endpoint/server"
+)
+
+func TestFingerprint_ToIPv6(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	require.NoError(t, err)
+
+	req.Header.Set("X-Forwarded-For", "2600:8802:4700:bee:d13c:c7fb:8e0f:84ff, 172.70.210.100")
+	fingerprint1, err := server.FingerprintFromRequest(req, time.Date(2022, 1, 1, 1, 2, 3, 4, time.UTC))
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(fingerprint1.ToIPv6().String(), "2001:db8::"))
+
+	fingerprint2, err := server.FingerprintFromRequest(req, time.Date(2022, 1, 1, 2, 3, 4, 5, time.UTC))
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(fingerprint2.ToIPv6().String(), "2001:db8::"))
+
+	require.NotEqual(t, fingerprint1, fingerprint2)
+}

--- a/server/fingerprint_test.go
+++ b/server/fingerprint_test.go
@@ -12,15 +12,24 @@ import (
 )
 
 func TestFingerprint_ToIPv6(t *testing.T) {
+	seed := uint64(0x4242420000004242)
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	require.NoError(t, err)
 
 	req.Header.Set("X-Forwarded-For", "2600:8802:4700:bee:d13c:c7fb:8e0f:84ff, 172.70.210.100")
-	fingerprint1, err := server.FingerprintFromRequest(req, time.Date(2022, 1, 1, 1, 2, 3, 4, time.UTC))
+	fingerprint1, err := server.FingerprintFromRequest(
+		req,
+		time.Date(2022, 1, 1, 1, 2, 3, 4, time.UTC),
+		seed,
+	)
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(fingerprint1.ToIPv6().String(), "2001:db8::"))
 
-	fingerprint2, err := server.FingerprintFromRequest(req, time.Date(2022, 1, 1, 2, 3, 4, 5, time.UTC))
+	fingerprint2, err := server.FingerprintFromRequest(
+		req,
+		time.Date(2022, 1, 1, 2, 3, 4, 5, time.UTC),
+		seed,
+	)
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(fingerprint2.ToIPv6().String(), "2001:db8::"))
 

--- a/server/http_client.go
+++ b/server/http_client.go
@@ -17,10 +17,10 @@ type rpcProxyClient struct {
 	logger      log.Logger
 	httpClient  http.Client
 	proxyURL    string
-	fingerprint string
+	fingerprint Fingerprint
 }
 
-func NewRPCProxyClient(logger log.Logger, proxyURL string, timeoutSeconds int, fingerprint string) RPCProxyClient {
+func NewRPCProxyClient(logger log.Logger, proxyURL string, timeoutSeconds int, fingerprint Fingerprint) RPCProxyClient {
 	return &rpcProxyClient{
 		logger:      logger,
 		httpClient:  http.Client{Timeout: time.Second * time.Duration(timeoutSeconds)},
@@ -35,8 +35,11 @@ func (n *rpcProxyClient) ProxyRequest(body []byte) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	if n.fingerprint != "" {
-		req.Header.Set("X-Flashbots-Fingerprint", n.fingerprint)
+	if n.fingerprint != 0 {
+		req.Header.Set(
+			"X-Forwarded-For",
+			n.fingerprint.ToIPv6().String(),
+		)
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")

--- a/server/http_client.go
+++ b/server/http_client.go
@@ -14,16 +14,18 @@ type RPCProxyClient interface {
 }
 
 type rpcProxyClient struct {
-	logger     log.Logger
-	httpClient http.Client
-	proxyURL   string
+	logger      log.Logger
+	httpClient  http.Client
+	proxyURL    string
+	fingerprint string
 }
 
-func NewRPCProxyClient(logger log.Logger, proxyURL string, timeoutSeconds int) RPCProxyClient {
+func NewRPCProxyClient(logger log.Logger, proxyURL string, timeoutSeconds int, fingerprint string) RPCProxyClient {
 	return &rpcProxyClient{
-		logger:     logger,
-		httpClient: http.Client{Timeout: time.Second * time.Duration(timeoutSeconds)},
-		proxyURL:   proxyURL,
+		logger:      logger,
+		httpClient:  http.Client{Timeout: time.Second * time.Duration(timeoutSeconds)},
+		proxyURL:    proxyURL,
+		fingerprint: fingerprint,
 	}
 }
 
@@ -32,6 +34,9 @@ func (n *rpcProxyClient) ProxyRequest(body []byte) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodPost, n.proxyURL, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, err
+	}
+	if n.fingerprint != "" {
+		req.Header.Set("X-Flashbots-Fingerprint", n.fingerprint)
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -106,7 +106,7 @@ func (r *RpcRequestHandler) process() {
 		return
 	}
 
-	fingerprint, err := r.getFingerprint()
+	fingerprint, _ := r.getFingerprint()
 	if fingerprint != "" {
 		r.logger = r.logger.New("fingerprint", fingerprint)
 	}

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -9,11 +9,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/google/uuid"
+	"golang.org/x/exp/rand"
 
 	"github.com/flashbots/rpc-endpoint/application"
 	"github.com/flashbots/rpc-endpoint/database"
 	"github.com/flashbots/rpc-endpoint/types"
 )
+
+var seed uint64 = uint64(rand.Int63())
 
 // RPC request handler for a single/ batch JSON-RPC request
 type RpcRequestHandler struct {
@@ -102,7 +105,7 @@ func (r *RpcRequestHandler) process() {
 		return
 	}
 
-	fingerprint, _ := FingerprintFromRequest(r.req, time.Now())
+	fingerprint, _ := FingerprintFromRequest(r.req, time.Now(), seed)
 	if fingerprint != 0 {
 		r.logger = r.logger.New("fingerprint", fingerprint.ToIPv6().String())
 	}

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -174,7 +174,6 @@ func (r *RpcRequestHandler) getFingerprint() (string, error) {
 	fingerprintPreimage := fmt.Sprintf("XFF:%s|UA:%s", xff, r.req.Header.Get("User-Agent"))
 	sum := xxhash.Sum64String(fingerprintPreimage)
 	fingerprint := fmt.Sprintf("%x", sum)
-	r.logger.Info("SOURCE TEST", "fingerprint", fingerprint, "preimage", fingerprintPreimage)
 	return fingerprint, nil
 }
 

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -3,15 +3,20 @@ package server
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/google/uuid"
+
 	"github.com/flashbots/rpc-endpoint/application"
 	"github.com/flashbots/rpc-endpoint/database"
 	"github.com/flashbots/rpc-endpoint/types"
-	"github.com/google/uuid"
 )
 
 // RPC request handler for a single/ batch JSON-RPC request
@@ -101,8 +106,13 @@ func (r *RpcRequestHandler) process() {
 		return
 	}
 
+	fingerprint, err := r.getFingerprint()
+	if fingerprint != "" {
+		r.logger = r.logger.New("fingerprint", fingerprint)
+	}
+
 	// create rpc proxy client for making proxy request
-	client := NewRPCProxyClient(r.logger, r.defaultProxyUrl, r.proxyTimeoutSeconds)
+	client := NewRPCProxyClient(r.logger, r.defaultProxyUrl, r.proxyTimeoutSeconds, fingerprint)
 
 	r.requestRecord.UpdateRequestEntry(r.req, http.StatusOK, "") // Data analytics
 
@@ -153,4 +163,71 @@ func (r *RpcRequestHandler) finishRequest() {
 		}
 	}()
 	r.logger.Info("Request finished", "duration", reqDuration.Seconds())
+}
+
+func (r *RpcRequestHandler) getFingerprint() (string, error) {
+	// X-Forwarded-For: 2600:8802:4700:bee:d13c:c7fb:8e0f:84ff, 172.70.210.100
+	xff, err := getXForwardedForIP(r.req)
+	if err != nil {
+		return "", err
+	}
+	fingerprintPreimage := fmt.Sprintf("XFF:%s|UA:%s", xff, r.req.Header.Get("User-Agent"))
+	sum := xxhash.Sum64String(fingerprintPreimage)
+	fingerprint := fmt.Sprintf("%x", sum)
+	r.logger.Info("SOURCE TEST", "fingerprint", fingerprint, "preimage", fingerprintPreimage)
+	return fingerprint, nil
+}
+
+func getXForwardedForIP(r *http.Request) (string, error) {
+	// gets the left-most non-private IP in the X-Forwarded-For header
+	xff := r.Header.Get("X-Forwarded-For")
+	if xff == "" {
+		return "", fmt.Errorf("no X-Forwarded-For header")
+	}
+	ips := strings.Split(xff, ",")
+	for _, ip := range ips {
+		if !isPrivateIP(ip) {
+			return ip, nil
+		}
+	}
+	return "", fmt.Errorf("no non-private IP in X-Forwarded-For header")
+}
+
+func isPrivateIP(ip string) bool {
+	// compare ip to RFC-1918 known private IP ranges
+	// https://en.wikipedia.org/wiki/Private_network
+	ipAddr := net.ParseIP(ip)
+	if ipAddr == nil {
+		return false
+	}
+
+	for _, cidr := range cidrs {
+		if cidr.Contains(ipAddr) {
+			return true
+		}
+	}
+	return false
+}
+
+// Taken from https://github.com/tomasen/realip/blob/master/realip.go
+// MIT Licensed, Copyright (c) 2018 SHEN SHENG
+var cidrs []*net.IPNet
+
+func init() {
+	maxCidrBlocks := []string{
+		"127.0.0.1/8",    // localhost
+		"10.0.0.0/8",     // 24-bit block
+		"172.16.0.0/12",  // 20-bit block
+		"192.168.0.0/16", // 16-bit block
+		"169.254.0.0/16", // link local address
+		"::1/128",        // localhost IPv6
+		"fc00::/7",       // unique local address IPv6
+		"fe80::/10",      // link local address IPv6
+	}
+
+	cidrs = make([]*net.IPNet, len(maxCidrBlocks))
+	for i, maxCidrBlock := range maxCidrBlocks {
+		_, cidr, _ := net.ParseCIDR(maxCidrBlock)
+		cidrs[i] = cidr
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	_ "net/http/pprof"
@@ -14,6 +15,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/cespare/xxhash/v2"
 
 	"github.com/flashbots/rpc-endpoint/adapters/webfile"
 	"github.com/flashbots/rpc-endpoint/application"
@@ -243,7 +246,9 @@ func (s *RpcEndPointServer) HandleHttpRequest(respw http.ResponseWriter, req *ht
 		return
 	}
 
-	s.logger.Info("SOURCE TEST", "X-Forwarded-For", req.Header.Get("X-Forwarded-For"))
+	fingerprintPreimage := fmt.Sprintf("XFF:%s|UA:%s", req.Header.Get("X-Forwarded-For"), req.Header.Get("User-Agent"))
+	fingerprint := xxhash.Sum64String(fingerprintPreimage)
+	s.logger.Info("SOURCE TEST", "fingerprint", fingerprint, "preimage", fingerprintPreimage)
 
 	request := NewRpcRequestHandler(s.logger, &respw, req, s.proxyUrl, s.proxyTimeoutSeconds, s.relaySigningKey, s.relayUrl, s.db, s.builderNameProvider.BuilderNames(), s.chainID, s.rpcCache)
 	request.process()

--- a/server/server.go
+++ b/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	_ "net/http/pprof"
@@ -15,8 +14,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"github.com/cespare/xxhash/v2"
 
 	"github.com/flashbots/rpc-endpoint/adapters/webfile"
 	"github.com/flashbots/rpc-endpoint/application"
@@ -118,7 +115,7 @@ func NewRpcEndPointServer(cfg Configuration) (*RpcEndPointServer, error) {
 
 func fetchNetworkIDBytes(cfg Configuration) ([]byte, error) {
 
-	cl := NewRPCProxyClient(cfg.Logger, cfg.ProxyUrl, cfg.ProxyTimeoutSeconds)
+	cl := NewRPCProxyClient(cfg.Logger, cfg.ProxyUrl, cfg.ProxyTimeoutSeconds, "")
 
 	_req := types.NewJsonRpcRequest(1, "net_version", []interface{}{})
 	jsonData, err := json.Marshal(_req)
@@ -245,10 +242,6 @@ func (s *RpcEndPointServer) HandleHttpRequest(respw http.ResponseWriter, req *ht
 		respw.WriteHeader(http.StatusOK)
 		return
 	}
-
-	fingerprintPreimage := fmt.Sprintf("XFF:%s|UA:%s", req.Header.Get("X-Forwarded-For"), req.Header.Get("User-Agent"))
-	fingerprint := xxhash.Sum64String(fingerprintPreimage)
-	s.logger.Info("SOURCE TEST", "fingerprint", fingerprint, "preimage", fingerprintPreimage)
 
 	request := NewRpcRequestHandler(s.logger, &respw, req, s.proxyUrl, s.proxyTimeoutSeconds, s.relaySigningKey, s.relayUrl, s.db, s.builderNameProvider.BuilderNames(), s.chainID, s.rpcCache)
 	request.process()

--- a/server/server.go
+++ b/server/server.go
@@ -115,7 +115,7 @@ func NewRpcEndPointServer(cfg Configuration) (*RpcEndPointServer, error) {
 
 func fetchNetworkIDBytes(cfg Configuration) ([]byte, error) {
 
-	cl := NewRPCProxyClient(cfg.Logger, cfg.ProxyUrl, cfg.ProxyTimeoutSeconds, "")
+	cl := NewRPCProxyClient(cfg.Logger, cfg.ProxyUrl, cfg.ProxyTimeoutSeconds, 0)
 
 	_req := types.NewJsonRpcRequest(1, "net_version", []interface{}{})
 	jsonData, err := json.Marshal(_req)

--- a/server/server.go
+++ b/server/server.go
@@ -22,8 +22,9 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/alicebob/miniredis"
-	"github.com/flashbots/rpc-endpoint/types"
 	"github.com/pkg/errors"
+
+	"github.com/flashbots/rpc-endpoint/types"
 )
 
 var Now = time.Now // used to mock time in tests
@@ -241,6 +242,8 @@ func (s *RpcEndPointServer) HandleHttpRequest(respw http.ResponseWriter, req *ht
 		respw.WriteHeader(http.StatusOK)
 		return
 	}
+
+	s.logger.Info("SOURCE TEST", "X-Forwarded-For", req.Header.Get("X-Forwarded-For"))
 
 	request := NewRpcRequestHandler(s.logger, &respw, req, s.proxyUrl, s.proxyTimeoutSeconds, s.relaySigningKey, s.relayUrl, s.db, s.builderNameProvider.BuilderNames(), s.chainID, s.rpcCache)
 	request.process()


### PR DESCRIPTION
## 📝 Summary

We are seeing abuse of our endpoint that is bypassing our firewall rules.  To help determine how they are getting past the firewall we need to log the "source" of the traffic in a privacy-preserving way.

~What I came up with is the `xxhash( x-forwarded-for + user-agent )` or more specifically the left-most non-private IP in the `X-Forwarded-For` and the `User-Agent` headers.~

However, after discussing w/ @0x416e746f6e he made the good point that `User-Agent` can be gamed by randomly generating a new UA w/ each request.  Furthermore, the fingerprint should *not* be long-term stable, as that would allow a malicious actor with access to Flashbot logs the ability to track user behavior long-term.  So now the hash is salted w/ the current timestamp truncated to the hour, and the UA is removed.

In addition, we currently use [`proxyd`](https://github.com/ethereum-optimism/infra/tree/main/proxyd) as our upstream which by default uses the `X-Forwarded-For` header for rate limiting.  Since `xxhash` is a `uint64` it actually fits perfectly in an IPv6 address, so we convert the fingerprint to a fake IPv6 address in the reserved "example address" documentation prefix from https://datatracker.ietf.org/doc/html/rfc3849 and insert this "IP" as the `X-Forwarded-For` field.

## ⛱ Motivation and Context

Give us to means to perform log aggregation to see if the offending traffic is coming from a single or multiple sources.

## 📚 References

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
