### PR TITLE
feat: Return local nonce when getTransactionCount request is signed

### DIFF
--- a/adapters/flashbots/signature.go
+++ b/adapters/flashbots/signature.go
@@ -16,7 +16,7 @@ var (
 	ErrInvalidSignature = errors.New("invalid signature provided")
 )
 
-func ParseSignature(header string, body []byte) (string, error) {
+func ParseSignature(header string, body []byte) (signingAddress string, err error) {
 	if header == "" {
 		return "", ErrNoSignature
 	}
@@ -29,7 +29,7 @@ func ParseSignature(header string, body []byte) (string, error) {
 	return VerifySignature(body, splitSig[0], splitSig[1])
 }
 
-func VerifySignature(body []byte, signingAddressStr, signatureStr string) (string, error) {
+func VerifySignature(body []byte, signingAddressStr, signatureStr string) (signingAddress string, err error) {
 	signature, err := hexutil.Decode(signatureStr)
 	if err != nil || len(signature) == 0 {
 		return "", fmt.Errorf("%w: %w", ErrInvalidSignature, err)

--- a/adapters/flashbots/signature.go
+++ b/adapters/flashbots/signature.go
@@ -1,0 +1,67 @@
+// Package flashbots provides methods for parsing the X-Flashbots-Signature header.
+package flashbots
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+var (
+	ErrNoSignature      = errors.New("no signature provided")
+	ErrInvalidSignature = errors.New("invalid signature provided")
+)
+
+func ParseSignature(header string, body []byte) (string, error) {
+	if header == "" {
+		return "", ErrNoSignature
+	}
+
+	splitSig := strings.Split(header, ":")
+	if len(splitSig) != 2 {
+		return "", ErrInvalidSignature
+	}
+
+	return VerifySignature(body, splitSig[0], splitSig[1])
+}
+
+func VerifySignature(body []byte, signingAddressStr, signatureStr string) (string, error) {
+	signature, err := hexutil.Decode(signatureStr)
+	if err != nil || len(signature) == 0 {
+		return "", fmt.Errorf("%w: %w", ErrInvalidSignature, err)
+	}
+
+	if signature[len(signature)-1] >= 27 {
+		signature[len(signature)-1] -= 27
+	}
+
+	hashedBody := crypto.Keccak256Hash(body).Hex()
+	messageHash := accounts.TextHash([]byte(hashedBody))
+	signaturePublicKeyBytes, err := crypto.Ecrecover(messageHash, signature)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidSignature, err)
+	}
+
+	publicKey, err := crypto.UnmarshalPubkey(signaturePublicKeyBytes)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidSignature, err)
+	}
+	signaturePubkey := *publicKey
+	signaturePubKeyAddress := crypto.PubkeyToAddress(signaturePubkey).Hex()
+
+	// case-insensitive equality check
+	if !strings.EqualFold(signaturePubKeyAddress, signingAddressStr) {
+		return "", fmt.Errorf("%w: signing address mismatch", ErrInvalidSignature)
+	}
+
+	signatureNoRecoverID := signature[:len(signature)-1] // remove recovery id
+	if !crypto.VerifySignature(signaturePublicKeyBytes, messageHash, signatureNoRecoverID) {
+		return "", fmt.Errorf("%w: %w", ErrInvalidSignature, err)
+	}
+
+	return signaturePubKeyAddress, nil
+}

--- a/adapters/flashbots/signature_test.go
+++ b/adapters/flashbots/signature_test.go
@@ -1,0 +1,80 @@
+package flashbots_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/flashbots/rpc-endpoint/adapters/flashbots"
+)
+
+func TestParseSignature(t *testing.T) {
+
+	// For most of these test cases, we first need to generate a signature
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	address := crypto.PubkeyToAddress(privateKey.PublicKey).Hex()
+	body := fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["%s","pending"],"id":1}`,
+		address,
+	)
+
+	signature, err := crypto.Sign(
+		accounts.TextHash([]byte(hexutil.Encode(crypto.Keccak256([]byte(body))))),
+		privateKey,
+	)
+	require.NoError(t, err)
+
+	header := fmt.Sprintf("%s:%s", address, hexutil.Encode(signature))
+
+	t.Run("header is empty", func(t *testing.T) {
+		_, err := flashbots.ParseSignature("", []byte{})
+		require.ErrorIs(t, err, flashbots.ErrNoSignature)
+	})
+
+	t.Run("header is valid", func(t *testing.T) {
+		signingAddress, err := flashbots.ParseSignature(header, []byte(body))
+		require.NoError(t, err)
+		require.Equal(t, address, signingAddress)
+	})
+
+	t.Run("header is invalid", func(t *testing.T) {
+		_, err := flashbots.ParseSignature("invalid", []byte(body))
+		require.ErrorIs(t, err, flashbots.ErrInvalidSignature)
+	})
+
+	t.Run("header has extra bytes", func(t *testing.T) {
+		_, err := flashbots.ParseSignature(header+"deadbeef", []byte(body))
+		require.ErrorIs(t, err, flashbots.ErrInvalidSignature)
+	})
+
+	t.Run("header has missing bytes", func(t *testing.T) {
+		_, err := flashbots.ParseSignature(header[:len(header)-8], []byte(body))
+		require.ErrorIs(t, err, flashbots.ErrInvalidSignature)
+	})
+
+	t.Run("body is empty", func(t *testing.T) {
+		_, err := flashbots.ParseSignature(header, []byte{})
+		require.ErrorIs(t, err, flashbots.ErrInvalidSignature)
+	})
+
+	t.Run("body is invalid", func(t *testing.T) {
+		_, err := flashbots.ParseSignature(header, []byte(`{}`))
+		require.ErrorIs(t, err, flashbots.ErrInvalidSignature)
+	})
+
+	t.Run("body has extra bytes", func(t *testing.T) {
+		_, err := flashbots.ParseSignature(header, []byte(body+"..."))
+		require.ErrorIs(t, err, flashbots.ErrInvalidSignature)
+	})
+
+	t.Run("body has missing bytes", func(t *testing.T) {
+		_, err := flashbots.ParseSignature(header, []byte(body[:len(body)-8]))
+		require.ErrorIs(t, err, flashbots.ErrInvalidSignature)
+	})
+}

--- a/server/request_intercepts.go
+++ b/server/request_intercepts.go
@@ -192,7 +192,8 @@ func (r *RpcRequest) intercept_signed_eth_getTransactionCount() (requestFinished
 		return false
 	}
 
-	resp := fmt.Sprintf("0x%x", nonce)
+	r.logger.Info("[eth_getTransactionCount] intercept", "nonce", nonce)
+	resp := fmt.Sprintf("0x%x", nonce+1)
 	r.writeRpcResult(resp)
 	return true
 }

--- a/server/request_intercepts.go
+++ b/server/request_intercepts.go
@@ -1,11 +1,9 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/flashbots/rpc-endpoint/adapters/flashbots"
 	"github.com/flashbots/rpc-endpoint/types"
 )
 
@@ -154,8 +152,7 @@ func (r *RpcRequest) intercept_eth_call_to_FlashRPC_Contract() (requestFinished 
 }
 
 func (r *RpcRequest) intercept_signed_eth_getTransactionCount() (requestFinished bool) {
-	signingAddress, err := flashbots.ParseSignature(r.flashbotsSignature, r.flashbotsSignatureBody)
-	if errors.Is(err, flashbots.ErrNoSignature) {
+	if r.flashbotsSigningAddress == "" {
 		r.logger.Info("[eth_getTransactionCount] No signature found")
 		return false
 	}
@@ -177,8 +174,8 @@ func (r *RpcRequest) intercept_signed_eth_getTransactionCount() (requestFinished
 		return false
 	}
 	addr = strings.ToLower(addr)
-	if addr != strings.ToLower(signingAddress) {
-		r.logger.Info("[eth_getTransactionCount] address mismatch", "addr", addr, "signingAddress", signingAddress)
+	if addr != strings.ToLower(r.flashbotsSigningAddress) {
+		r.logger.Info("[eth_getTransactionCount] address mismatch", "addr", addr, "signingAddress", r.flashbotsSigningAddress)
 		return false
 	}
 

--- a/server/request_intercepts.go
+++ b/server/request_intercepts.go
@@ -156,24 +156,29 @@ func (r *RpcRequest) intercept_eth_call_to_FlashRPC_Contract() (requestFinished 
 func (r *RpcRequest) intercept_signed_eth_getTransactionCount() (requestFinished bool) {
 	signingAddress, err := flashbots.ParseSignature(r.flashbotsSignature, r.flashbotsSignatureBody)
 	if errors.Is(err, flashbots.ErrNoSignature) {
+		r.logger.Info("[eth_getTransactionCount] No signature found")
 		return false
 	}
 
 	if len(r.jsonReq.Params) != 2 {
+		r.logger.Info("[eth_getTransactionCount] Invalid params")
 		return false
 	}
 
 	blockSpecifier, ok := r.jsonReq.Params[1].(string)
 	if !ok || blockSpecifier != "pending" {
+		r.logger.Info("[eth_getTransactionCount] non-pending blockSpecifier")
 		return false
 	}
 
 	addr, ok := r.jsonReq.Params[0].(string)
 	if !ok {
+		r.logger.Info("[eth_getTransactionCount] non-string address")
 		return false
 	}
 	addr = strings.ToLower(addr)
 	if addr != strings.ToLower(signingAddress) {
+		r.logger.Info("[eth_getTransactionCount] address mismatch", "addr", addr, "signingAddress", signingAddress)
 		return false
 	}
 
@@ -183,6 +188,7 @@ func (r *RpcRequest) intercept_signed_eth_getTransactionCount() (requestFinished
 		return false
 	}
 	if !found {
+		r.logger.Info("[eth_getTransactionCount] No nonce found")
 		return false
 	}
 

--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -60,7 +60,7 @@ func NewRpcRequest(
 	rpcCache *application.RpcCache,
 ) *RpcRequest {
 	return &RpcRequest{
-		logger:                     logger,
+		logger:                     logger.With("method", jsonReq.Method),
 		client:                     client,
 		jsonReq:                    jsonReq,
 		relaySigningKey:            relaySigningKey,

--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -42,6 +42,8 @@ type RpcRequest struct {
 	urlParams                  URLParameters
 	chainID                    []byte
 	rpcCache                   *application.RpcCache
+	flashbotsSignature         string
+	flashbotsSignatureBody     []byte
 }
 
 func NewRpcRequest(
@@ -102,6 +104,7 @@ func (r *RpcRequest) ProcessRequest() *types.JsonRpcResponse {
 	case r.jsonReq.Method == "eth_sendRawTransaction":
 		r.ethSendRawTxEntry.WhiteHatBundleId = r.whitehatBundleId
 		r.handle_sendRawTransaction()
+	case r.jsonReq.Method == "eth_getTransactionCount" && r.intercept_signed_eth_getTransactionCount():
 	case r.jsonReq.Method == "eth_getTransactionCount" && r.intercept_mm_eth_getTransactionCount(): // intercept if MM needs to show an error to user
 	case r.jsonReq.Method == "eth_call" && r.intercept_eth_call_to_FlashRPC_Contract(): // intercept if Flashbots isRPC contract
 	case r.jsonReq.Method == "web3_clientVersion":


### PR DESCRIPTION
## 📝 Summary

Implements an "MVP" version of #150: When a `eth_getTransactionCount` RPC request is signed with a `X-Flashbots-Signature` header matching the target address we return the "next nonce" from Redis instead of proxying the request.

## ⛱ Motivation and Context

This feature is desirable for Wallets that want to use `eth_getTransctionCount` to manage user nonces while still preserving users' privacy.

Note that this is the _MVP_ implementation on this functionality, in that it uses the existing `RState.GetSenderMaxNonce(addr)` check.  As noted in #150 this current code does not respect "nonce gaps" so a follow-on PR will be needed later to correctly handle nonce gaps (most likely via adding a per-address Redis Sorted Set ("ZSet") as mentioned in the issue).  However, this implementation will work for most scenarios, and will allow us to get feedback from wallets before working on the more-detailed implementation.

## 📚 References

Tested as follows:

```
# Check an address nonce
> cast nonce 0x2485aaa7c5453e04658378358f5e028150dc7606 --rpc-url https://rpc-sepolia.flashbots.net --block pending
54

#Send a private tx from this address
cast send .... --rpc-url https://rpc-sepolia.flashbots.net

#Confirm cast nonce still returns the same value
> cast nonce 0x2485aaa7c5453e04658378358f5e028150dc7606 --rpc-url https://rpc-sepolia.flashbots.net --block pending
54

# Call the RPC w/ the X-Flashbots-Signature (code snippet)
responseBytes := sendSignedRPC(t, url, map[string]interface{}{
			"jsonrpc": "2.0",
			"id":      1,
			"method":  "eth_getTransactionCount",
			"params":  []interface{}{"0x2485aaa7c5453e04658378358f5e028150dc7606", "pending"},
		})
{"id":1,"result":"0x37","jsonrpc":"2.0"}

# Once the private tx is mined, confirm both cast nonce and the RPC return 0x37
> cast --to-hex $(cast nonce 0x2485aaa7c5453e04658378358f5e028150dc7606 --rpc-url https://rpc-sepolia.flashbots.net --block pending)
0x37

responseBytes := sendSignedRPC(t, url, map[string]interface{}{
			"jsonrpc": "2.0",
			"id":      1,
			"method":  "eth_getTransactionCount",
			"params":  []interface{}{"0x2485aaa7c5453e04658378358f5e028150dc7606", "pending"},
		})
{"id":1,"result":"0x37","jsonrpc":"2.0"}
```

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
