### PR TITLE
chore(signature): Double-check signature logic using third-party tools.

### DIFF
--- a/adapters/flashbots/signature_test.go
+++ b/adapters/flashbots/signature_test.go
@@ -2,6 +2,7 @@ package flashbots_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts"
@@ -77,4 +78,41 @@ func TestParseSignature(t *testing.T) {
 		_, err := flashbots.ParseSignature(header, []byte(body[:len(body)-8]))
 		require.ErrorIs(t, err, flashbots.ErrInvalidSignature)
 	})
+}
+
+func TestVerifySignatureFromMetaMask(t *testing.T) {
+	// Source: use the "Sign Message" feature in Etherscan
+	// to sign the keccak256 hash of `Hello`
+	// Published to https://etherscan.io/verifySig/255560
+	messageHash := crypto.Keccak256Hash([]byte("Hello")).Hex()
+	require.Equal(t, `0x06b3dfaec148fb1bb2b066f10ec285e7c9bf402ab32aa78a5d38e34566810cd2`, messageHash)
+	address := `0x4bE0Cd2553356b4ABb8b6a1882325dAbC8d3013D`
+	signatureHash := `0xbf36915334f8fa93894cd54d491c31a89dbf917e9a4402b2779b73d21ecf46e36ff07db2bef6d10e92c99a02c1c5ea700b0b674dfa5d3ce9220822a7ebcc17101b`
+	header := address + ":" + signatureHash
+	signingAddress, err := flashbots.ParseSignature(
+		header,
+		[]byte(`Hello`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, strings.ToLower(address), strings.ToLower(signingAddress))
+}
+
+func TestVerifySignatureCast(t *testing.T) {
+	// Source: use `cast wallet sign` in the `cast` CLI
+	// to sign the keccak256 hash of `Hello`:
+	// `cast wallet sign --interactive $(cast from-utf8 $(cast keccak Hello))`
+	// NOTE: The call to from-utf8 is required as cast wallet sign
+	// interprets inputs with a leading 0x as a byte array, not a string.
+	// Published to https://etherscan.io/verifySig/255562
+	messageHash := crypto.Keccak256Hash([]byte("Hello")).Hex()
+	require.Equal(t, `0x06b3dfaec148fb1bb2b066f10ec285e7c9bf402ab32aa78a5d38e34566810cd2`, messageHash)
+	address := `0x2485Aaa7C5453e04658378358f5E028150Dc7606`
+	signatureHash := `0xff2aa92eb8d8c2ca04f1755a4ddbff4bda6a5c9cefc8b706d5d8a21d3aa6fe7a20d3ec062fb5a4c1656fd2c14a8b33ca378b830d9b6168589bfee658e83745cc1b`
+	header := address + ":" + signatureHash
+	signingAddress, err := flashbots.ParseSignature(
+		header,
+		[]byte(`Hello`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, strings.ToLower(address), strings.ToLower(signingAddress))
 }


### PR DESCRIPTION
## 📝 Summary

Adds two more unit tests for `flashbots.ParseSignature` using two signatures generated via MetaMask and `cast`.

## ⛱ Motivation and Context

I realized that the existing `TestParseSignature` test uses the `crypto` package to generate the signatures, and since this is the same package we use internally to verify the signatures it was possible that we had a bug in both our uses for generation and validation of the package.  So as an extra sanity check I generated two additional signatures using MetaMask and `cast` to confirm that our signature verification code works across multiple signature implementations.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

I actually wasn't aware of this nice extra feature of etherscan where signatures can be published that also offers a nice UI for prompting your wallet to generate a signature: https://etherscan.io/verifiedSignatures#

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
