### PR TITLE
fix: Compare local nonce w/ backend to detect invalidated cache

### DIFF
--- a/server/redisstate.go
+++ b/server/redisstate.go
@@ -282,6 +282,11 @@ func (s *RedisState) GetSenderMaxNonce(txFrom string) (senderMaxNonce uint64, fo
 	return senderMaxNonce, true, nil
 }
 
+func (s *RedisState) DelSenderMaxNonce(txFrom string) error {
+	key := RedisKeySenderMaxNonce(txFrom)
+	return s.RedisClient.Del(context.Background(), key).Err()
+}
+
 // Block transactions, with a specific return value (eg. "nonce too low")
 func (s *RedisState) SetBlockedTxHash(txHash string, returnValue string) error {
 	key := RedisKeyBlockedTxHash(txHash)

--- a/server/request_intercepts.go
+++ b/server/request_intercepts.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+
 	"github.com/flashbots/rpc-endpoint/types"
 )
 
@@ -200,11 +202,13 @@ func (r *RpcRequest) intercept_signed_eth_getTransactionCount() (requestFinished
 
 	backendTxCount := uint64(0)
 	if r.jsonRes.Result != nil {
-		if err := json.Unmarshal(r.jsonRes.Result, &backendTxCount); err != nil {
-			r.logger.Info("[ProcessRequest] Proxy to node failed", "method", r.jsonReq.Method)
+		count := hexutil.Uint64(0)
+		if err := json.Unmarshal(r.jsonRes.Result, &count); err != nil {
+			r.logger.Info("[ProcessRequest] Unmarshal backend response failed", "method", r.jsonReq.Method)
 			r.writeRpcError("internal server error", types.JsonRpcInternalError)
 			return true
 		}
+		backendTxCount = uint64(count)
 		r.logger.Info("[eth_getTransactionCount] intercept", "backendTxCount", backendTxCount, "addr", addr)
 	}
 

--- a/server/request_intercepts.go
+++ b/server/request_intercepts.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -179,7 +180,9 @@ func (r *RpcRequest) intercept_signed_eth_getTransactionCount() (requestFinished
 		return false
 	}
 
-	nonce, found, err := RState.GetSenderMaxNonce(addr)
+	// since it's possible that the user sent another tx via another provider, we need to check the nonce from
+	// both the backend and our cache, and return the greater of the two
+	cachedNonce, found, err := RState.GetSenderMaxNonce(addr)
 	if err != nil {
 		r.logger.Error("[eth_getTransactionCount] Redis:GetSenderMaxNonce error", "error", err)
 		return false
@@ -188,9 +191,36 @@ func (r *RpcRequest) intercept_signed_eth_getTransactionCount() (requestFinished
 		r.logger.Info("[eth_getTransactionCount] No nonce found")
 		return false
 	}
+	if !r.proxyRequestRead() {
+		r.logger.Info("[ProcessRequest] Proxy to node failed", "method", r.jsonReq.Method)
+		r.writeRpcError("internal server error", types.JsonRpcInternalError)
+		return true
+	}
+	r.logger.Info("[eth_getTransactionCount] intercept", "cachedNonce", cachedNonce, "addr", addr)
 
-	r.logger.Info("[eth_getTransactionCount] intercept", "nonce", nonce)
-	resp := fmt.Sprintf("0x%x", nonce+1)
+	backendTxCount := uint64(0)
+	if r.jsonRes.Result != nil {
+		if err := json.Unmarshal(r.jsonRes.Result, &backendTxCount); err != nil {
+			r.logger.Info("[ProcessRequest] Proxy to node failed", "method", r.jsonReq.Method)
+			r.writeRpcError("internal server error", types.JsonRpcInternalError)
+			return true
+		}
+		r.logger.Info("[eth_getTransactionCount] intercept", "backendTxCount", backendTxCount, "addr", addr)
+	}
+
+	// return either the cached nonce plus one, or the backend tx count
+	txCount := cachedNonce + 1
+	if backendTxCount > txCount {
+		txCount = backendTxCount
+		// since the cached value is invalid lets remove it from redis
+		r.logger.Info("[eth_getTransactionCount] intercept invalidated nonce", "addr", addr)
+		if err := RState.DelSenderMaxNonce(addr); err != nil {
+			// log the error but continue
+			r.logger.Error("[eth_getTransactionCount] Redis:DelSenderMaxNonce error", "error", err, "addr", addr)
+		}
+	}
+
+	resp := fmt.Sprintf("0x%x", txCount)
 	r.writeRpcResult(resp)
 	return true
 }


### PR DESCRIPTION
## 📝 Summary

If the user submits a tx via some pathway other than our rpc-endpoint (e.g. the public mempool or another private pool) then our cache of the users max nonce was not being invalidated.

## ⛱ Motivation and Context

Steps to reproduce:

- Send a tx via rpc-endpoint.
- This causes the nonce to be stored in redis for 24h
- Send another tx via the public mempool
- Wait for this mempool tx to be mined
- Query rpc-endpoint via signed `eth_getTransactionCount` RPC
- Note that the old value is still returned.

The fix:

Before returning nonce from cache, we still do a backend request as normal, if it returns a tx count greater than the one derived from our cache we return it instead and invalidate our cache.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
