### PR TITLE
mempool configs support, reverting tx support

### DIFF
--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -317,11 +317,12 @@ func (r *RpcRequest) sendTxToRelay() {
 	if err != nil {
 		if errors.Is(err, flashbotsrpc.ErrRelayErrorResponse) {
 			r.logger.Info("[sendTxToRelay] Relay error response", "error", err, "rawTx", r.rawTxHex)
-			r.writeRpcError(err.Error(), types.JsonRpcInternalError)
 		} else {
 			r.logger.Error("[sendTxToRelay] Relay call failed", "error", err, "rawTx", r.rawTxHex)
-			r.writeRpcError(err.Error(), types.JsonRpcInternalError)
 		}
+		// todo: we need to change the way we call bundle-relay-api as it's not json-rpc compatible so we don't get proper
+		// error code/text
+		r.writeRpcError("internal error", types.JsonRpcInternalError)
 		return
 	}
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -278,7 +278,7 @@ func TestRelayTx(t *testing.T) {
 
 	// Ensure that request was signed properly
 	pubkey := crypto.PubkeyToAddress(relaySigningKey.PublicKey).Hex()
-	require.Equal(t, pubkey+":0x04084726a086ebd58bc8eb4d4d1387aade5372e1b421ea0636ee4fcc7410b0cb650fbfdc06a7aeb1c34d0982c9bee903ac2622c51134f160dac32ad1e61331d301", testutils.MockBackendLastRawRequest.Header.Get("X-Flashbots-Signature"))
+	require.Equal(t, pubkey+":0x446933e9be3df94013f61764c18dfa4e521b2d822c0cc7b42063b9bbc8960f697c0dd1d9835cb22b83b0765106d7fdbb9d2257d0dfcbf3feefb0e972f872266100", testutils.MockBackendLastRawRequest.Header.Get("X-Flashbots-Signature"))
 
 	// Check result - should be the tx hash
 	var res string

--- a/types/types.go
+++ b/types/types.go
@@ -112,8 +112,10 @@ type SendPrivateTxRequestWithPreferences struct {
 }
 
 type TxPrivacyPreferences struct {
-	Hints    []string `json:"hints"`
-	Builders []string `json:"builders"`
+	Hints         []string `json:"hints"`
+	Builders      []string `json:"builders"`
+	UseMempool    bool     `json:"useMempool"`
+	CustomMempool string   `json:"customMempool"`
 }
 
 type TxValidityPreferences struct {
@@ -126,7 +128,8 @@ type RefundConfig struct {
 }
 
 type PrivateTxPreferences struct {
-	Privacy  TxPrivacyPreferences  `json:"privacy"`
-	Validity TxValidityPreferences `json:"validity"`
-	Fast     bool                  `json:"fast"`
+	Privacy     TxPrivacyPreferences  `json:"privacy"`
+	Validity    TxValidityPreferences `json:"validity"`
+	Fast        bool                  `json:"fast"`
+	AllowRevert bool                  `json:"allowRevert"`
 }


### PR DESCRIPTION
## 📝 Summary

Allow new configurations for private transactions

## ⛱ Motivation and Context

There are use-cases when it makes sense to configure transaction with fallback to mempool or revertable

## 📚 References


---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
