### PR TITLE
fix: rpc_endpoint_requests insert sql

### DIFF
--- a/database/postgres_store.go
+++ b/database/postgres_store.go
@@ -32,7 +32,7 @@ func (d *postgresStore) Close() {
 
 func (d *postgresStore) SaveRequestEntry(entry RequestEntry) error {
 	query := `INSERT INTO rpc_endpoint_requests
-	(id, received_at, request_duration_ms, is_batch_request, num_request_in_batch, http_method, http_url, http_query_param, http_response_status, ip_hash, origin, host, error) VALUES (:id, :received_at, :request_duration_ms, :is_batch_request, :num_request_in_batch, :http_method, :http_url, :http_query_param, :http_response_status, :ip_hash, :origin, :host, :error)`
+	(id, received_at, request_duration_ms, is_batch_request, num_request_in_batch, http_method, http_url, http_query_param, http_response_status, origin, host, error) VALUES (:id, :received_at, :request_duration_ms, :is_batch_request, :num_request_in_batch, :http_method, :http_url, :http_query_param, :http_response_status, :origin, :host, :error)`
 	ctx, cancel := context.WithTimeout(context.Background(), connTimeOut)
 	defer cancel()
 	_, err := d.DB.NamedExecContext(ctx, query, entry)


### PR DESCRIPTION
## 📝 Summary
fix: https://github.com/flashbots/rpc-endpoint/issues/161
<!--- A general summary of your changes -->

## ⛱ Motivation and Context

rpc_endpoint_requests don't have filed `ip_hash`, save to db will failed
```
CREATE TABLE rpc_endpoint_requests(
    id uuid not null unique primary key default gen_random_uuid(),
    received_at timestamp with time zone not null,
    inserted_at timestamp with time zone not null default now(),
    request_duration_ms bigint not null,
    is_batch_request boolean,
    num_request_in_batch integer,
    http_method varchar(10) not null,
    http_url varchar(100) not null,
    http_query_param text,
    http_response_status integer,
    origin text,
    host text,
    error text
);
```

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
