### PR TITLE
Add AutoSniper to Whitelist

### DIFF
--- a/server/whitelist.go
+++ b/server/whitelist.go
@@ -8,6 +8,7 @@ var allowedLargeTxTargets = map[string]bool{
 	"0x47312450B3Ac8b5b8e247a6bB6d523e7605bDb60": true, // StarkWare SHARP Verifier (Mainnet)
 	"0x8f97970aC5a9aa8D130d35146F5b59c4aef57963": true, // StarkWare SHARP Verifier (Goerli)
 	"0x07ec0D28e50322Eb0C159B9090ecF3aeA8346DFe": true, // StarkWare SHARP Verifier (Sepolia)
+	"0x000000000000feA5F4B241F9E77B4D43B76798a9": true, // oSnipe AutoSniper contract
 }
 
 func init() {


### PR DESCRIPTION
## 📝 Summary

Adds oSnipe's autosniper contract to the list of large tx targets.

## ⛱ Motivation and Context

The autosniper is a multicaller that sometimes accepts a very large list of transactions to execute. These transactions are being rejected by Flashbots, and as a result they must be resubmitted to other builders that do not enforce a tx size limit.

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
