### PR TITLE
fix(nonce): Reset user nonce if tx fails.

### DIFF
--- a/server/redisstate_test.go
+++ b/server/redisstate_test.go
@@ -146,13 +146,14 @@ func TestSenderOfTxHash(t *testing.T) {
 
 	txFrom := "0x0Sender"
 	txHash := "0xDeadBeef"
+	txNonce := uint64(1337)
 
 	val, found, err := redisState.GetSenderOfTxHash(txHash)
 	require.Nil(t, err, err)
 	require.False(t, found)
 	require.Equal(t, "", val)
 
-	err = redisState.SetSenderOfTxHash(txHash, txFrom)
+	err = redisState.SetSenderAndNonceOfTxHash(txHash, txFrom, txNonce)
 	require.Nil(t, err, err)
 
 	val, found, err = redisState.GetSenderOfTxHash(txHash)
@@ -172,7 +173,7 @@ func TestSenderMaxNonce(t *testing.T) {
 	require.False(t, found)
 	require.Equal(t, uint64(0), val)
 
-	err = redisState.SetSenderMaxNonce(txFrom, 17)
+	err = redisState.SetSenderMaxNonce(txFrom, 17, 0)
 	require.Nil(t, err, err)
 
 	val, found, err = redisState.GetSenderMaxNonce(txFrom)
@@ -180,7 +181,7 @@ func TestSenderMaxNonce(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, uint64(17), val)
 
-	err = redisState.SetSenderMaxNonce(txFrom, 16)
+	err = redisState.SetSenderMaxNonce(txFrom, 16, 10)
 	require.Nil(t, err, err)
 
 	val, found, err = redisState.GetSenderMaxNonce(txFrom)
@@ -188,7 +189,7 @@ func TestSenderMaxNonce(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, uint64(17), val)
 
-	err = redisState.SetSenderMaxNonce(txFrom, 18)
+	err = redisState.SetSenderMaxNonce(txFrom, 18, 0)
 	require.Nil(t, err, err)
 
 	val, found, err = redisState.GetSenderMaxNonce(txFrom)

--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -258,7 +258,7 @@ func (r *RpcRequest) sendTxToRelay() {
 		}
 	}
 
-	go RState.SetSenderMaxNonce(r.txFrom, r.tx.Nonce())
+	go RState.SetSenderMaxNonce(r.txFrom, r.tx.Nonce(), r.urlParams.blockRange)
 
 	// only allow large non-blob transactions to certain addresses - default max tx size is 128KB
 	// https://github.com/ethereum/go-ethereum/blob/master/core/tx_pool.go#L53

--- a/server/request_processor_test.go
+++ b/server/request_processor_test.go
@@ -1,12 +1,18 @@
 package server
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/alicebob/miniredis"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/flashbots/rpc-endpoint/database"
 	"github.com/flashbots/rpc-endpoint/testutils"
 	"github.com/flashbots/rpc-endpoint/types"
 	"github.com/stretchr/testify/require"
@@ -102,4 +108,112 @@ func TestRequestshouldSendTxToRelay(t *testing.T) {
 
 	shouldSend = !request.blockResendingTxToRelay(txHash)
 	require.True(t, shouldSend)
+}
+
+type mockClient struct {
+	err          error
+	nextResponse *http.Response
+}
+
+func (m mockClient) ProxyRequest(body []byte) (*http.Response, error) {
+	return m.nextResponse, m.err
+}
+
+var _ RPCProxyClient = &mockClient{}
+
+func TestFailedTxShouldResetMaxNonce(t *testing.T) {
+	setupRedis()
+	setupMockTxApi()
+
+	sender := "0x6bc84f6a0fabbd7102be338c048fe0ae54948c2e"
+	txHash := "0x58e5a0fc7fbc849eddc100d44e86276168a8c7baaa5604e44ba6f5eb8ba1b7eb"
+
+	mockClient := &mockClient{}
+	privKey, _ := crypto.GenerateKey()
+	require.NotNil(t, privKey)
+
+	t.Run("setup", func(t *testing.T) {
+		err := RState.SetSenderMaxNonce(sender, 4, 10)
+		require.NoError(t, err)
+
+		status, err := GetTxStatus(txHash)
+		require.NoError(t, err)
+		require.Equal(t, types.TxStatusUnknown, status.Status)
+	})
+
+	// Send a tx
+	// NOTE: this portion is somewhat brittle and possibly prone to breakage
+	// if we see this test failing then we should invest in proper mock tooling
+	// around RpcRequest.
+	t.Run("send tx", func(t *testing.T) {
+		r := RpcRequest{}
+		r.jsonReq = &types.JsonRpcRequest{
+			Id:     1,
+			Method: "eth_sendRawTransaction",
+			Params: []any{
+				"0xf86c258502540be40083035b609482e041e84074fc5f5947d4d27e3c44f824b7a1a187b1a2bc2ec500008078a04a7db627266fa9a4116e3f6b33f5d245db40983234eb356261f36808909d2848a0166fa098a2ce3bda87af6000ed0083e3bf7cc31c6686b670bd85cbc6da2d6e85",
+			},
+			Version: "2.0",
+		}
+		r.logger = log.New()
+		r.client = mockClient
+		r.ethSendRawTxEntry = &database.EthSendRawTxEntry{}
+		r.relaySigningKey = privKey
+		mockClient.nextResponse = &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewBufferString(`{"results":"0x58e5a0fc7fbc849eddc100d44e86276168a8c7baaa5604e44ba6f5eb8ba1b7eb"}`)),
+		}
+
+		// we expect handle_sendRawTransaction to set the
+		// nonce in the RState cache to the txs nonce (0x25)
+		r.handle_sendRawTransaction()
+
+		// but actually the nonce is set asynchronously so we need to first
+		// sleep until we see it in the cache.
+		for i := 0; i < 5; i++ {
+			_, found, _ := RState.GetSenderMaxNonce(sender)
+			if !found {
+				time.Sleep(time.Millisecond * time.Duration(i*10))
+			}
+		}
+
+		// once found we can check the results
+		require.Equal(t, r.tx.Nonce(), uint64(0x25))
+		maxNonce, found, err := RState.GetSenderMaxNonce(sender)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, r.tx.Nonce(), maxNonce)
+	})
+
+	// mark tx failed in mock status API
+	t.Run("fail tx", func(t *testing.T) {
+		testutils.MockTxApiStatusForHash[txHash] = types.TxStatusFailed
+	})
+
+	// and now simulate the user sending a eth_getTransactionReceipt request
+	t.Run("eth_getTransactionReceipt", func(t *testing.T) {
+		r := RpcRequest{}
+		r.logger = log.New()
+		r.jsonReq = &types.JsonRpcRequest{
+			Id:      1,
+			Method:  "eth_getTransactionReceipt",
+			Params:  []any{txHash},
+			Version: "2.0",
+		}
+		response := &types.JsonRpcResponse{
+			Id:      1,
+			Result:  json.RawMessage(`null`),
+			Error:   nil,
+			Version: "2.0",
+		}
+		r.check_post_getTransactionReceipt(response)
+	})
+
+	// ensure that the max nonce is cleared
+	t.Run("check nonce", func(t *testing.T) {
+		maxNonce, found, err := RState.GetSenderMaxNonce(sender)
+		require.NoError(t, err)
+		require.Equal(t, uint64(0x0), maxNonce)
+		require.False(t, found)
+	})
 }

--- a/server/request_sendrawtx.go
+++ b/server/request_sendrawtx.go
@@ -87,10 +87,10 @@ func (r *RpcRequest) handle_sendRawTransaction() {
 		return
 	}
 
-	// Remember sender of the tx, for lookup in getTransactionReceipt to possibly set nonce-fix
-	err = RState.SetSenderOfTxHash(txHashLower, txFromLower)
+	// Remember sender and nonce of the tx, for lookup in getTransactionReceipt to possibly set nonce-fix
+	err = RState.SetSenderAndNonceOfTxHash(txHashLower, txFromLower, r.tx.Nonce())
 	if err != nil {
-		r.logger.Error("[sendRawTransaction] Redis:SetSenderOfTxHash failed: %v", err)
+		r.logger.Error("[sendRawTransaction] Redis:SetSenderAndNonceOfTxHash failed: %v", err)
 	}
 	var txToAddr string
 	if r.tx.To() != nil { // to address will be nil for contract creation tx

--- a/server/url_params.go
+++ b/server/url_params.go
@@ -174,7 +174,7 @@ func ExtractParametersFromUrl(reqUrl *url.URL, allBuilders []string) (params URL
 	blockRange := normalizedQuery["blockrange"]
 	if len(blockRange) != 0 {
 		brange, err := strconv.Atoi(blockRange[0])
-		if err != nil {
+		if err != nil || brange < 0 {
 			return params, ErrIncorrectURLParam
 		}
 		params.blockRange = brange


### PR DESCRIPTION
## 📝 Summary

With the addition of #151 the rpc-endpoint can return the cached nonce if the `eth_getTransactionCount` request is signed.

However, this didn't take into account the fact that txs can fail, in which case we want to invalidate the cache.

Also, with the new `blockRange` URL param we want to shorten the nonce cache duration to match.

## ⛱ Motivation and Context

Say a user sends a tx w/ nonce 100, and it fails.  Then sends a signed `eth_getTransactionCount` request within the default nonce expiration window.  We would tell the user to use nonce 101 when really they should send a new tx w/ 100 since that tx never made it on-chain.

We relay on the fact that wallets send `eth_getTransactionReceipt` to check the tx status, and use piggy back off the existing logic already added in #13 by also clearing the cached max nonce if the tx fails.

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test` 
* [x] `go mod tidy`
