### PR TITLE
New hint to enable full data sharing (except signature)

### DIFF
--- a/server/url_params.go
+++ b/server/url_params.go
@@ -45,6 +45,17 @@ func normalizeQueryParams(url *url.URL) map[string][]string {
 	return normalizedQuery
 }
 
+var allowedHints = map[string]struct{}{
+	"hash":              struct{}{},
+	"contract_address":  struct{}{},
+	"function_selector": struct{}{},
+	"logs":              struct{}{},
+	"calldata":          struct{}{},
+	"default_logs":      struct{}{},
+	"tx_hash":           struct{}{},
+	"tx_full":           struct{}{},
+}
+
 // ExtractParametersFromUrl extracts the auction preference from the url query
 // Allowed query params:
 //   - hint: mev share hints, can be set multiple times, default: hash, special_logs
@@ -67,8 +78,9 @@ func ExtractParametersFromUrl(reqUrl *url.URL, allBuilders []string) (params URL
 		}
 		for _, hint := range hintQuery {
 			// valid hints are: "hash", "contract_address", "function_selector", "logs", "calldata"
-			if hint != "hash" && hint != "contract_address" && hint != "function_selector" && hint != "logs" && hint != "calldata" && hint != "default_logs" {
+			if _, ok := allowedHints[hint]; !ok {
 				return params, ErrIncorrectAuctionHints
+
 			}
 		}
 		hint = hintQuery

--- a/server/url_params.go
+++ b/server/url_params.go
@@ -53,7 +53,7 @@ var allowedHints = map[string]struct{}{
 	"calldata":          struct{}{},
 	"default_logs":      struct{}{},
 	"tx_hash":           struct{}{},
-	"tx_full":           struct{}{},
+	"full":              struct{}{},
 }
 
 // ExtractParametersFromUrl extracts the auction preference from the url query


### PR DESCRIPTION
## 📝 Summary

Allow `full` hint that is now supported by `mev-share` which shares all the tx details except signature

## ⛱ Motivation and Context

There are usecases, where possible (probabilistic) frontrunning is not a concern, so for those txs we support now full data sharing to enable perfect backrun caclulation.  

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
