### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/server/request_processor.go
+++ b/server/request_processor.go
@@ -482,7 +482,7 @@ func (r *RpcRequest) GetAddressNonceRange(address string) (minNonce, maxNonce ui
 
 	// Get maximum nonce by looking at redis, which has current pending transactions
 	_redisMaxNonce, _, _ := RState.GetSenderMaxNonce(r.txFrom)
-	maxNonce = Max(minNonce, _redisMaxNonce)
+	maxNonce = max(minNonce, _redisMaxNonce)
 	return minNonce, maxNonce, nil
 }
 

--- a/server/util.go
+++ b/server/util.go
@@ -17,20 +17,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func Min(a uint64, b uint64) uint64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func Max(a uint64, b uint64) uint64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func GetTx(rawTxHex string) (*ethtypes.Transaction, error) {
 	if len(rawTxHex) < 2 {
 		return nil, errors.New("invalid raw transaction")


### PR DESCRIPTION
## 📝 Summary

<!--- A general summary of your changes -->

Use the built-in max/min from the standard library in Go 1.21 to simplify the code.
https://pkg.go.dev/builtin@go1.21.0#max

## ⛱ Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [ ] `make lint`
* [ ] `make test`
* [ ] `go mod tidy`
