### PR TITLE
fix: duplicate requestId log

### DIFF
--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -183,7 +183,7 @@ func (r *RpcRequestHandler) finishRequest() {
 	go func() {
 		// Save both request entry and raw tx entries if present
 		if err := r.requestRecord.SaveRecord(); err != nil {
-			log.Error("saveRecord failed", "requestId", r.requestRecord.requestEntry.Id, "error", err, "requestId", r.uid)
+			log.Error("saveRecord failed", "requestId", r.requestRecord.requestEntry.Id, "error", err)
 		}
 	}()
 	r.logger.Info("Request finished", "duration", reqDuration.Seconds())


### PR DESCRIPTION
## 📝 Summary

This fixes a duplicate in a log. `requestId` is in there twice, and it will be the same value for both (assigned to the same value on [line 79](https://github.com/flashbots/rpc-endpoint/pull/178/files#diff-2f7e4ab125195dbb9b3a4d07913c52966782d37fc2a11eff7f48ceaa909e5968L79)).

## ⛱ Motivation and Context

Reduce confusion in logs

## 📚 References

<!-- Any interesting external links to documentation, articles, tweets which add value to the PR -->

---

## ✅ I have run these commands

* [x] `make lint`
* [x] `make test`
* [x] `go mod tidy`
