### PR TITLE
Add header-based configuration override for QuickNode integration

### DIFF
--- a/server/configuration_watcher_test.go
+++ b/server/configuration_watcher_test.go
@@ -1,0 +1,54 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigurationWatcherPresets(t *testing.T) {
+	// Test the core business logic: valid presets are parsed and available
+	config := CustomersConfig{
+		URLs: map[string][]string{
+			"quicknode": {"/fast?originId=quicknode"},
+		},
+		Presets: map[string]string{
+			"quicknode": "/fast?originId=quicknode&refund=0x1234567890123456789012345678901234567890:90",
+		},
+	}
+	
+	watcher, err := NewConfigurationWatcher(config)
+	require.NoError(t, err)
+	require.NotNil(t, watcher)
+	
+	// Core functionality: preset should be parsed and available
+	preset, exists := watcher.ParsedPresets["quicknode"]
+	require.True(t, exists)
+	require.Equal(t, "quicknode", preset.originId)
+	require.True(t, preset.fast)
+	require.Equal(t, 1, len(preset.pref.Validity.Refund))
+}
+
+func TestConfigurationWatcherInvalidPresets(t *testing.T) {
+	// Test graceful degradation: invalid presets are skipped, don't break startup
+	config := CustomersConfig{
+		URLs: map[string][]string{
+			"test": {"/fast?originId=test"},
+		},
+		Presets: map[string]string{
+			"valid":   "/fast?originId=valid",
+			"invalid": "://invalid-url", // This should be skipped
+		},
+	}
+	
+	watcher, err := NewConfigurationWatcher(config)
+	require.NoError(t, err) // Should not fail startup
+	
+	// Valid preset loaded
+	_, exists := watcher.ParsedPresets["valid"]
+	require.True(t, exists)
+	
+	// Invalid preset skipped
+	_, exists = watcher.ParsedPresets["invalid"]
+	require.False(t, exists)
+}


### PR DESCRIPTION
## Summary
- Implements `X-Flashbots-Origin-ID` header support for guaranteed refund collection
- Adds preset configuration system to ensure partners receive fixed refund percentages
- Maintains backward compatibility with existing URL parameter flows

## Implementation Details
- **ConfigurationWatcher**: Extended to support `presets` field with graceful error handling
- **Request Handler**: New `getEffectiveParameters()` method checks header first, falls back to URL parsing
- **Configuration**: Preset URLs are pre-parsed at startup for performance and early error detection

## Key Behavior
When `X-Flashbots-Origin-ID` header is present:
1. Looks up preset configuration for the origin ID
2. Uses preset parameters, **completely ignoring URL parameters**  
3. Falls back to normal URL parsing if no preset found

## Testing
- Unit tests cover preset parsing and header override logic
- Tests graceful degradation for invalid preset configurations
- Ready for testnet deployment and integration testing

## Configuration Updates Required
- Sepolia testnet: Already configured with test preset
- Production: Needs real QuickNode refund address (coordinate with deployment)

🤖 Generated with [Claude Code](https://claude.ai/code)